### PR TITLE
Add OCI skills media types, constants, and platform types

### DIFF
--- a/oci/skills/doc.go
+++ b/oci/skills/doc.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+Package skills provides OCI artifact types, media types, and local storage for
+ToolHive skill packages.
+
+A skill is an OCI artifact containing MCP server configuration, prompt files,
+and metadata. This package defines the constants, data structures, and storage
+layer that the rest of the ToolHive ecosystem uses to package, push, pull, and
+cache skills as OCI images.
+
+# Media Types and Constants
+
+Standard OCI media types and ToolHive-specific annotation/label keys:
+
+	// Artifact type identifies a skill manifest
+	skills.ArtifactTypeSkill // "dev.toolhive.skills.v1"
+
+	// Annotations carry metadata in manifests
+	skills.AnnotationSkillName
+	skills.AnnotationSkillVersion
+
+	// Labels carry metadata in OCI image configs
+	skills.LabelSkillName
+	skills.LabelSkillFiles
+
+# Stability
+
+This package is Alpha. Breaking changes are possible between minor versions.
+*/
+package skills

--- a/oci/skills/mediatypes.go
+++ b/oci/skills/mediatypes.go
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Artifact type for skill identification.
+const (
+	// ArtifactTypeSkill identifies skill artifacts in manifests.
+	ArtifactTypeSkill = "dev.toolhive.skills.v1"
+)
+
+// OCI Image Index media type.
+const (
+	// MediaTypeImageIndex is the OCI image index media type.
+	MediaTypeImageIndex = "application/vnd.oci.image.index.v1+json"
+)
+
+// Standard OCI media types for Kubernetes image volume compatibility.
+const (
+	// MediaTypeImageManifest is the OCI image manifest media type.
+	MediaTypeImageManifest = "application/vnd.oci.image.manifest.v1+json"
+
+	// MediaTypeImageConfig is the standard OCI image config media type.
+	MediaTypeImageConfig = "application/vnd.oci.image.config.v1+json"
+
+	// MediaTypeImageLayer is the standard OCI image layer media type.
+	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar+gzip"
+)
+
+// Annotation keys for skill metadata in manifests.
+const (
+	// AnnotationCreated is the OCI standard annotation for creation time.
+	AnnotationCreated = "org.opencontainers.image.created"
+
+	// AnnotationSkillName is the annotation key for skill name.
+	AnnotationSkillName = "dev.toolhive.skills.name"
+
+	// AnnotationSkillDescription is the annotation key for skill description.
+	AnnotationSkillDescription = "dev.toolhive.skills.description"
+
+	// AnnotationSkillVersion is the annotation key for skill version.
+	AnnotationSkillVersion = "dev.toolhive.skills.version"
+
+	// AnnotationSkillRequires is the annotation key for skill external dependencies (JSON array of OCI references).
+	AnnotationSkillRequires = "dev.toolhive.skills.requires"
+)
+
+// Label keys for skill metadata in OCI image config.
+const (
+	// LabelSkillName is the label key for skill name.
+	LabelSkillName = "dev.toolhive.skills.name"
+
+	// LabelSkillDescription is the label key for skill description.
+	LabelSkillDescription = "dev.toolhive.skills.description"
+
+	// LabelSkillVersion is the label key for skill version.
+	LabelSkillVersion = "dev.toolhive.skills.version"
+
+	// LabelSkillAllowedTools is the label key for allowed tools (JSON array).
+	LabelSkillAllowedTools = "dev.toolhive.skills.allowedTools"
+
+	// LabelSkillLicense is the label key for skill license.
+	LabelSkillLicense = "dev.toolhive.skills.license"
+
+	// LabelSkillFiles is the label key for skill files (JSON array).
+	LabelSkillFiles = "dev.toolhive.skills.files"
+)
+
+// SkillConfig represents skill metadata extracted from OCI image config labels.
+type SkillConfig struct {
+	Name          string            `json:"name"`
+	Description   string            `json:"description"`
+	Version       string            `json:"version,omitempty"`
+	AllowedTools  []string          `json:"allowedTools,omitempty"`
+	License       string            `json:"license,omitempty"`
+	Compatibility string            `json:"compatibility,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	Files         []string          `json:"files"`
+}
+
+// ImageConfig represents a standard OCI image configuration.
+// This structure is required for Kubernetes image volume compatibility.
+type ImageConfig struct {
+	Architecture string          `json:"architecture"`
+	OS           string          `json:"os"`
+	Config       ImageConfigData `json:"config,omitempty"`
+	RootFS       RootFS          `json:"rootfs"`
+	History      []HistoryEntry  `json:"history,omitempty"`
+}
+
+// ImageConfigData contains container configuration including labels.
+type ImageConfigData struct {
+	Labels map[string]string `json:"Labels,omitempty"`
+}
+
+// RootFS describes the rootfs of the image.
+type RootFS struct {
+	Type    string   `json:"type"`
+	DiffIDs []string `json:"diff_ids"`
+}
+
+// HistoryEntry describes a layer in the image history.
+type HistoryEntry struct {
+	Created   string `json:"created,omitempty"`
+	CreatedBy string `json:"created_by,omitempty"`
+}
+
+// SkillConfigFromImageConfig extracts SkillConfig from OCI image config labels.
+func SkillConfigFromImageConfig(imgConfig *ImageConfig) (*SkillConfig, error) {
+	if imgConfig == nil {
+		return nil, fmt.Errorf("image config is nil")
+	}
+
+	labels := imgConfig.Config.Labels
+	if labels == nil {
+		return nil, fmt.Errorf("oci config has no labels")
+	}
+
+	config := &SkillConfig{
+		Name:        labels[LabelSkillName],
+		Description: labels[LabelSkillDescription],
+		Version:     labels[LabelSkillVersion],
+		License:     labels[LabelSkillLicense],
+	}
+
+	if config.Name == "" {
+		return nil, fmt.Errorf("skill name is required in labels")
+	}
+
+	// Parse JSON-encoded arrays
+	if toolsJSON := labels[LabelSkillAllowedTools]; toolsJSON != "" {
+		if err := json.Unmarshal([]byte(toolsJSON), &config.AllowedTools); err != nil {
+			return nil, fmt.Errorf("parsing allowed tools: %w", err)
+		}
+	}
+
+	if filesJSON := labels[LabelSkillFiles]; filesJSON != "" {
+		if err := json.Unmarshal([]byte(filesJSON), &config.Files); err != nil {
+			return nil, fmt.Errorf("parsing files: %w", err)
+		}
+	}
+
+	return config, nil
+}
+
+// Platform represents a target platform for OCI artifacts.
+type Platform struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+}
+
+// String returns the platform in "os/arch" format.
+func (p Platform) String() string {
+	return p.OS + "/" + p.Architecture
+}
+
+// ParsePlatform parses a platform string in "os/arch" format.
+func ParsePlatform(s string) (Platform, error) {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return Platform{}, fmt.Errorf("invalid platform format: %q (expected os/arch)", s)
+	}
+	osName := strings.TrimSpace(parts[0])
+	arch := strings.TrimSpace(parts[1])
+	if osName == "" || arch == "" {
+		return Platform{}, fmt.Errorf("invalid platform format: %q (os and arch cannot be empty)", s)
+	}
+	return Platform{OS: osName, Architecture: arch}, nil
+}
+
+// DefaultPlatforms are the default platforms for skill artifacts.
+// These cover most Kubernetes clusters.
+var DefaultPlatforms = []Platform{
+	{OS: "linux", Architecture: "amd64"},
+	{OS: "linux", Architecture: "arm64"},
+}
+
+// ImageIndex represents an OCI image index (multi-platform manifest list).
+type ImageIndex struct {
+	SchemaVersion int               `json:"schemaVersion"`
+	MediaType     string            `json:"mediaType"`
+	ArtifactType  string            `json:"artifactType,omitempty"`
+	Manifests     []IndexDescriptor `json:"manifests"`
+	Annotations   map[string]string `json:"annotations,omitempty"`
+}
+
+// IndexDescriptor describes a manifest in an image index.
+type IndexDescriptor struct {
+	MediaType   string            `json:"mediaType"`
+	Digest      string            `json:"digest"`
+	Size        int64             `json:"size"`
+	Platform    *Platform         `json:"platform,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// ParseRequiresAnnotation parses skill dependency references from manifest annotations.
+// Returns nil if the annotation is missing or invalid.
+func ParseRequiresAnnotation(annotations map[string]string) []string {
+	requiresJSON := annotations[AnnotationSkillRequires]
+	if requiresJSON == "" {
+		return nil
+	}
+
+	var refs []string
+	if err := json.Unmarshal([]byte(requiresJSON), &refs); err != nil {
+		// Invalid annotation format - return nil rather than propagating error
+		// since annotations may come from older versions or external sources
+		return nil
+	}
+	return refs
+}

--- a/oci/skills/mediatypes_test.go
+++ b/oci/skills/mediatypes_test.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkillConfigFromImageConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		config    *ImageConfig
+		wantName  string
+		wantErr   bool
+		wantTools []string
+		wantFiles []string
+	}{
+		{
+			name: "all fields populated",
+			config: &ImageConfig{
+				Config: ImageConfigData{
+					Labels: map[string]string{
+						LabelSkillName:         "my-skill",
+						LabelSkillDescription:  "A test skill",
+						LabelSkillVersion:      "1.0.0",
+						LabelSkillLicense:      "Apache-2.0",
+						LabelSkillAllowedTools: `["tool1","tool2"]`,
+						LabelSkillFiles:        `["file1.txt","file2.txt"]`,
+					},
+				},
+			},
+			wantName:  "my-skill",
+			wantTools: []string{"tool1", "tool2"},
+			wantFiles: []string{"file1.txt", "file2.txt"},
+		},
+		{
+			name: "minimal config",
+			config: &ImageConfig{
+				Config: ImageConfigData{
+					Labels: map[string]string{
+						LabelSkillName: "minimal-skill",
+					},
+				},
+			},
+			wantName: "minimal-skill",
+		},
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: true,
+		},
+		{
+			name: "nil labels",
+			config: &ImageConfig{
+				Config: ImageConfigData{Labels: nil},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing name",
+			config: &ImageConfig{
+				Config: ImageConfigData{
+					Labels: map[string]string{
+						LabelSkillDescription: "no name",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid allowed tools JSON",
+			config: &ImageConfig{
+				Config: ImageConfigData{
+					Labels: map[string]string{
+						LabelSkillName:         "bad-tools",
+						LabelSkillAllowedTools: "not-json",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid files JSON",
+			config: &ImageConfig{
+				Config: ImageConfigData{
+					Labels: map[string]string{
+						LabelSkillName:  "bad-files",
+						LabelSkillFiles: "not-json",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := SkillConfigFromImageConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, got.Name)
+			if tt.wantTools != nil {
+				assert.Equal(t, tt.wantTools, got.AllowedTools)
+			}
+			if tt.wantFiles != nil {
+				assert.Equal(t, tt.wantFiles, got.Files)
+			}
+		})
+	}
+}
+
+func TestParsePlatform(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    Platform
+		wantErr bool
+	}{
+		{
+			name:  "linux/amd64",
+			input: "linux/amd64",
+			want:  Platform{OS: "linux", Architecture: "amd64"},
+		},
+		{
+			name:  "linux/arm64",
+			input: "linux/arm64",
+			want:  Platform{OS: "linux", Architecture: "arm64"},
+		},
+		{
+			name:    "no slash",
+			input:   "linuxamd64",
+			wantErr: true,
+		},
+		{
+			name:    "too many parts",
+			input:   "linux/amd64/v8",
+			wantErr: true,
+		},
+		{
+			name:    "empty os",
+			input:   "/amd64",
+			wantErr: true,
+		},
+		{
+			name:    "empty arch",
+			input:   "linux/",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParsePlatform(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPlatformString(t *testing.T) {
+	t.Parallel()
+
+	p := Platform{OS: "linux", Architecture: "amd64"}
+	assert.Equal(t, "linux/amd64", p.String())
+}
+
+func TestParseRequiresAnnotation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        []string
+	}{
+		{
+			name: "valid refs",
+			annotations: map[string]string{
+				AnnotationSkillRequires: `["ghcr.io/org/skill1:v1","ghcr.io/org/skill2:v2"]`,
+			},
+			want: []string{"ghcr.io/org/skill1:v1", "ghcr.io/org/skill2:v2"},
+		},
+		{
+			name:        "empty annotations",
+			annotations: map[string]string{},
+			want:        nil,
+		},
+		{
+			name: "missing annotation",
+			annotations: map[string]string{
+				"other.key": "value",
+			},
+			want: nil,
+		},
+		{
+			name: "invalid JSON",
+			annotations: map[string]string{
+				AnnotationSkillRequires: "not-json",
+			},
+			want: nil,
+		},
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			want:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseRequiresAnnotation(tt.annotations)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDefaultPlatforms(t *testing.T) {
+	t.Parallel()
+
+	require.Len(t, DefaultPlatforms, 2)
+	assert.Equal(t, Platform{OS: "linux", Architecture: "amd64"}, DefaultPlatforms[0])
+	assert.Equal(t, Platform{OS: "linux", Architecture: "arm64"}, DefaultPlatforms[1])
+}


### PR DESCRIPTION
## Summary

- Introduce `oci/skills` package with OCI media types, annotation/label constants, and data structures for ToolHive skill artifacts
- Port from Skillet's `internal/infrastructure/oci/mediatypes.go` with namespace changes (`dev.toolhive.skills.*`), bundle removal, and `import-shadowing` fix
- Add `doc.go` with Alpha stability notice following `httperr/doc.go` pattern
- Comprehensive table-driven tests with testify (100% error-path coverage)

This is **PR 1 of 2** for [stacklok/toolhive-core#14](https://github.com/stacklok/toolhive-core/issues/14). PR 2 (store + interfaces) depends on types defined here.

Part of epic: [stacklok/stacklok-epics#239](https://github.com/stacklok/stacklok-epics/issues/239)

## Test plan

- [x] `task lint` — 0 issues
- [x] `task test` — all pass with `-race`
- [x] `task license-check` — SPDX headers valid
- [ ] Reviewer: verify constant namespaces match `dev.toolhive.skills.*` convention
- [ ] Reviewer: confirm no bundle-related code carried over from Skillet

🤖 Generated with [Claude Code](https://claude.com/claude-code)