### PR TITLE
Add NewHandler to logging package

### DIFF
--- a/logging/doc.go
+++ b/logging/doc.go
@@ -49,6 +49,14 @@ Inject a buffer to capture log output in tests:
 	logger.Info("test message")
 	// inspect buf.String()
 
+# Handler Access
+
+Use [NewHandler] when you need to wrap the handler with middleware:
+
+	base := logging.NewHandler(logging.WithLevel(slog.LevelDebug))
+	wrapped := &myMiddleware{Handler: base}
+	logger := slog.New(wrapped)
+
 # Stability
 
 This package is Alpha stability. The API may change without notice.


### PR DESCRIPTION
The following PR adds a NewHandler function that returns a slog.Handler for use cases that require handler middleware wrapping (e.g., trace injection). New now delegates to NewHandler internally.
