### PR TITLE
Migrate JSON schemas to draft 2020-12 and add release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish Release Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Upload schema artifacts to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            registry/types/data/skill.schema.json \
+            registry/types/data/upstream-registry.schema.json \
+            registry/types/data/publisher-provided.schema.json \
+            registry/types/data/toolhive-legacy-registry.schema.json \
+            --clobber

--- a/registry/types/data/publisher-provided.schema.json
+++ b/registry/types/data/publisher-provided.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/publisher-provided.schema.json",
   "title": "ToolHive Publisher-Provided Extensions Schema",
   "description": "Schema for ToolHive-specific metadata placed under _meta['io.modelcontextprotocol.registry/publisher-provided'] in MCP server definitions. This schema defines the structure of publisher extensions that ToolHive adds to servers in the upstream MCP registry format.",
@@ -9,7 +9,7 @@
       "type": "object",
       "description": "ToolHive publisher namespace containing server-specific extensions keyed by identifier (OCI image reference for container servers, URL for remote servers)",
       "additionalProperties": {
-        "$ref": "#/definitions/server_extensions"
+        "$ref": "#/$defs/server_extensions"
       }
     }
   },
@@ -17,7 +17,7 @@
     "type": "object",
     "description": "Other publisher namespaces may contain arbitrary extensions"
   },
-  "definitions": {
+  "$defs": {
     "server_extensions": {
       "type": "object",
       "description": "Extensions for MCP servers. Container servers (keyed by OCI image reference) may use permissions, args, provenance, docker_tags, and proxy_port. Remote servers (keyed by URL) may use oauth_config and env_vars. All servers share status, tier, tools, tags, metadata, and custom_metadata.",
@@ -60,15 +60,15 @@
           "type": "array",
           "description": "Full MCP Tool definitions describing the tools available from this server, including name, description, inputSchema, and annotations",
           "items": {
-            "$ref": "#/definitions/tool_definition"
+            "$ref": "#/$defs/tool_definition"
           }
         },
         "metadata": {
-          "$ref": "#/definitions/metadata"
+          "$ref": "#/$defs/metadata"
         },
         "permissions": {
           "description": "Security permissions for container-based servers",
-          "$ref": "#/definitions/permissions"
+          "$ref": "#/$defs/permissions"
         },
         "args": {
           "type": "array",
@@ -79,7 +79,7 @@
         },
         "provenance": {
           "description": "Supply chain provenance for container-based servers",
-          "$ref": "#/definitions/provenance"
+          "$ref": "#/$defs/provenance"
         },
         "docker_tags": {
           "type": "array",
@@ -97,13 +97,13 @@
         },
         "oauth_config": {
           "description": "OAuth/OIDC configuration for remote servers",
-          "$ref": "#/definitions/oauth_config"
+          "$ref": "#/$defs/oauth_config"
         },
         "env_vars": {
           "type": "array",
           "description": "Environment variables for remote server client configuration",
           "items": {
-            "$ref": "#/definitions/environment_variable"
+            "$ref": "#/$defs/environment_variable"
           }
         },
         "custom_metadata": {
@@ -129,7 +129,7 @@
           "format": "date-time"
         },
         "kubernetes": {
-          "$ref": "#/definitions/kubernetes_metadata"
+          "$ref": "#/$defs/kubernetes_metadata"
         }
       },
       "additionalProperties": false
@@ -179,7 +179,7 @@
           "description": "Name of the permission profile"
         },
         "network": {
-          "$ref": "#/definitions/network_permissions"
+          "$ref": "#/$defs/network_permissions"
         },
         "read": {
           "type": "array",
@@ -212,7 +212,7 @@
       "description": "Network access permissions for the MCP server",
       "properties": {
         "outbound": {
-          "$ref": "#/definitions/outbound_permissions"
+          "$ref": "#/$defs/outbound_permissions"
         }
       },
       "additionalProperties": false
@@ -290,7 +290,7 @@
           "examples": ["https://token.actions.githubusercontent.com"]
         },
         "attestation": {
-          "$ref": "#/definitions/verified_attestation"
+          "$ref": "#/$defs/verified_attestation"
         }
       },
       "additionalProperties": false

--- a/registry/types/data/toolhive-legacy-registry.schema.json
+++ b/registry/types/data/toolhive-legacy-registry.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/stacklok/toolhive-core/main/registry/types/data/toolhive-legacy-registry.schema.json",
   "title": "ToolHive MCP Server Registry Schema",
   "description": "JSON Schema for the ToolHive MCP server registry. This schema validates the structure and content of registry.json entries for MCP servers. See docs/registry/management.md and docs/registry/heuristics.md for inclusion criteria and management processes.",
@@ -16,7 +16,7 @@
       "description": "Collection of MCP server entries indexed by server name",
       "patternProperties": {
         "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
-          "$ref": "#/definitions/server"
+          "$ref": "#/$defs/server"
         }
       },
       "additionalProperties": false
@@ -26,7 +26,7 @@
       "description": "Collection of remote MCP server entries indexed by server name",
       "patternProperties": {
         "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
-          "$ref": "#/definitions/remote_server"
+          "$ref": "#/$defs/remote_server"
         }
       },
       "additionalProperties": false
@@ -35,7 +35,7 @@
       "type": "array",
       "description": "Collection of group definitions containing related MCP servers",
       "items": {
-        "$ref": "#/definitions/group"
+        "$ref": "#/$defs/group"
       }
     },
     "version": {
@@ -44,7 +44,7 @@
       "pattern": "^\\d+\\.\\d+\\.\\d+$"
     }
   },
-  "definitions": {
+  "$defs": {
     "server": {
       "type": "object",
       "description": "MCP server entry definition",
@@ -88,7 +88,7 @@
           "type": "array",
           "description": "Environment variables that can be passed to the server",
           "items": {
-            "$ref": "#/definitions/environment_variable"
+            "$ref": "#/$defs/environment_variable"
           }
         },
         "image": {
@@ -104,7 +104,7 @@
         },
         "metadata": {
           "description": "Additional information about the server such as popularity metrics",
-          "$ref": "#/definitions/metadata"
+          "$ref": "#/$defs/metadata"
         },
         "name": {
           "type": "string",
@@ -120,11 +120,11 @@
         },
         "permissions": {
           "description": "Security profile and access permissions for the server",
-          "$ref": "#/definitions/permissions"
+          "$ref": "#/$defs/permissions"
         },
         "provenance": {
           "description": "Verification and signing metadata",
-          "$ref": "#/definitions/provenance"
+          "$ref": "#/$defs/provenance"
         },
         "repository_url": {
           "type": "string",
@@ -228,7 +228,7 @@
       "required": [],
       "properties": {
         "network": {
-          "$ref": "#/definitions/network_permissions"
+          "$ref": "#/$defs/network_permissions"
         },
         "read": {
           "type": "array",
@@ -264,7 +264,7 @@
       "required": [],
       "properties": {
         "outbound": {
-          "$ref": "#/definitions/outbound_permissions"
+          "$ref": "#/$defs/outbound_permissions"
         }
       },
       "additionalProperties": false
@@ -369,7 +369,7 @@
         },
         "attestation": {
           "description": "Verified attestation information",
-          "$ref": "#/definitions/verified_attestation"
+          "$ref": "#/$defs/verified_attestation"
         }
       },
       "additionalProperties": false
@@ -566,23 +566,23 @@
           "type": "array",
           "description": "HTTP headers for authentication to the remote server",
           "items": {
-            "$ref": "#/definitions/header"
+            "$ref": "#/$defs/header"
           }
         },
         "oauth_config": {
           "description": "OAuth/OIDC configuration for authentication",
-          "$ref": "#/definitions/oauth_config"
+          "$ref": "#/$defs/oauth_config"
         },
         "env_vars": {
           "type": "array",
           "description": "Environment variables for client-side configuration",
           "items": {
-            "$ref": "#/definitions/environment_variable"
+            "$ref": "#/$defs/environment_variable"
           }
         },
         "metadata": {
           "description": "Additional information about the server",
-          "$ref": "#/definitions/metadata"
+          "$ref": "#/$defs/metadata"
         },
         "repository_url": {
           "type": "string",
@@ -630,7 +630,7 @@
           "description": "Collection of MCP server entries within this group indexed by server name",
           "patternProperties": {
             "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
-              "$ref": "#/definitions/server"
+              "$ref": "#/$defs/server"
             }
           },
           "additionalProperties": false
@@ -640,7 +640,7 @@
           "description": "Collection of remote MCP server entries within this group indexed by server name",
           "patternProperties": {
             "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
-              "$ref": "#/definitions/remote_server"
+              "$ref": "#/$defs/remote_server"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
The following PR:
- Migrate `publisher-provided.schema.json` and `toolhive-legacy-registry.schema.json` from draft-07 to 2020-12             
(`definitions` → `$defs`, updated `$schema` URI)
- All four schemas are now consistently on draft 2020-12
- Add release workflow that attaches the four schema files as GitHub Release assets when a version tag is pushed
