### PR TITLE
Remove additionalProperties: false from registry schemas

### DIFF
--- a/registry/types/data/publisher-provided.schema.json
+++ b/registry/types/data/publisher-provided.schema.json
@@ -21,18 +21,28 @@
     "server_extensions": {
       "type": "object",
       "description": "Extensions for MCP servers. Container servers (keyed by OCI image reference) may use permissions, args, provenance, docker_tags, and proxy_port. Remote servers (keyed by URL) may use oauth_config and env_vars. All servers share status, tier, tools, tags, metadata, and custom_metadata.",
-      "required": ["status"],
+      "required": [
+        "status"
+      ],
       "properties": {
         "status": {
           "type": "string",
           "description": "Current status of the server",
-          "enum": ["active", "deprecated", "Active", "Deprecated"],
+          "enum": [
+            "active",
+            "deprecated",
+            "Active",
+            "Deprecated"
+          ],
           "default": "active"
         },
         "tier": {
           "type": "string",
           "description": "Tier classification of the server",
-          "enum": ["Official", "Community"]
+          "enum": [
+            "Official",
+            "Community"
+          ]
         },
         "tools": {
           "type": "array",
@@ -111,8 +121,7 @@
           "description": "Custom user-defined metadata",
           "additionalProperties": true
         }
-      },
-      "additionalProperties": false
+      }
     },
     "metadata": {
       "type": "object",
@@ -131,8 +140,7 @@
         "kubernetes": {
           "$ref": "#/$defs/kubernetes_metadata"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "kubernetes_metadata": {
       "type": "object",
@@ -141,7 +149,11 @@
         "kind": {
           "type": "string",
           "description": "Kubernetes resource kind (e.g., MCPServer, VirtualMCPServer, MCPRemoteProxy)",
-          "examples": ["MCPServer", "VirtualMCPServer", "MCPRemoteProxy"]
+          "examples": [
+            "MCPServer",
+            "VirtualMCPServer",
+            "MCPRemoteProxy"
+          ]
         },
         "namespace": {
           "type": "string",
@@ -165,10 +177,14 @@
         "transport": {
           "type": "string",
           "description": "Transport type configured for the Kubernetes workload (applicable to MCPServer)",
-          "enum": ["stdio", "sse", "streamable-http", "http"]
+          "enum": [
+            "stdio",
+            "sse",
+            "streamable-http",
+            "http"
+          ]
         }
-      },
-      "additionalProperties": false
+      }
     },
     "permissions": {
       "type": "object",
@@ -204,8 +220,7 @@
           "description": "Whether the container should run in privileged mode",
           "default": false
         }
-      },
-      "additionalProperties": false
+      }
     },
     "network_permissions": {
       "type": "object",
@@ -214,8 +229,7 @@
         "outbound": {
           "$ref": "#/$defs/outbound_permissions"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "outbound_permissions": {
       "type": "object",
@@ -252,8 +266,7 @@
           "description": "Whether to allow all outbound connections (insecure, use with caution)",
           "default": false
         }
-      },
-      "additionalProperties": false
+      }
     },
     "provenance": {
       "type": "object",
@@ -263,7 +276,10 @@
           "type": "string",
           "description": "Sigstore TUF repository host for provenance verification",
           "format": "hostname",
-          "examples": ["tuf-repo.github.com", "tuf-repo-cdn.sigstore.dev"]
+          "examples": [
+            "tuf-repo.github.com",
+            "tuf-repo-cdn.sigstore.dev"
+          ]
         },
         "repository_uri": {
           "type": "string",
@@ -281,19 +297,24 @@
         "runner_environment": {
           "type": "string",
           "description": "Build environment where the server was built",
-          "examples": ["github-hosted", "gitlab-hosted", "self-hosted"]
+          "examples": [
+            "github-hosted",
+            "gitlab-hosted",
+            "self-hosted"
+          ]
         },
         "cert_issuer": {
           "type": "string",
           "description": "Certificate issuer for provenance verification",
           "format": "uri",
-          "examples": ["https://token.actions.githubusercontent.com"]
+          "examples": [
+            "https://token.actions.githubusercontent.com"
+          ]
         },
         "attestation": {
           "$ref": "#/$defs/verified_attestation"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "verified_attestation": {
       "type": "object",
@@ -311,8 +332,7 @@
         "predicate": {
           "description": "Attestation predicate data"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "oauth_config": {
       "type": "object",
@@ -366,8 +386,7 @@
           "type": "string",
           "description": "OAuth 2.0 resource indicator (RFC 8707)"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "environment_variable": {
       "type": "object",
@@ -396,13 +415,14 @@
           "type": "string",
           "description": "Default value if the environment variable is not provided"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "tool_definition": {
       "type": "object",
       "description": "An MCP Tool definition describing a tool available from this server",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",

--- a/registry/types/data/skill.schema.json
+++ b/registry/types/data/skill.schema.json
@@ -38,7 +38,11 @@
     "status": {
       "type": "string",
       "description": "Current status of the skill",
-      "enum": ["active", "deprecated", "archived"],
+      "enum": [
+        "active",
+        "deprecated",
+        "archived"
+      ],
       "default": "active"
     },
     "title": {
@@ -92,17 +96,21 @@
       "additionalProperties": true
     }
   },
-  "additionalProperties": false,
   "$defs": {
     "skill_package": {
       "type": "object",
       "description": "Distribution package reference (OCI or Git)",
-      "required": ["registryType"],
+      "required": [
+        "registryType"
+      ],
       "properties": {
         "registryType": {
           "type": "string",
           "description": "Package registry type",
-          "enum": ["oci", "git"]
+          "enum": [
+            "oci",
+            "git"
+          ]
         },
         "identifier": {
           "type": "string",
@@ -133,13 +141,14 @@
           "type": "string",
           "description": "Path within the repository"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "skill_icon": {
       "type": "object",
       "description": "Display icon for the skill",
-      "required": ["src"],
+      "required": [
+        "src"
+      ],
       "properties": {
         "src": {
           "type": "string",
@@ -157,8 +166,7 @@
           "type": "string",
           "description": "Accessibility label for the icon"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "skill_repository": {
       "type": "object",
@@ -173,8 +181,7 @@
           "type": "string",
           "description": "Repository type (e.g. git)"
         }
-      },
-      "additionalProperties": false
+      }
     }
   }
 }

--- a/registry/types/data/toolhive-legacy-registry.schema.json
+++ b/registry/types/data/toolhive-legacy-registry.schema.json
@@ -4,7 +4,11 @@
   "title": "ToolHive MCP Server Registry Schema",
   "description": "JSON Schema for the ToolHive MCP server registry. This schema validates the structure and content of registry.json entries for MCP servers. See docs/registry/management.md and docs/registry/heuristics.md for inclusion criteria and management processes.",
   "type": "object",
-  "required": ["last_updated", "servers", "version"],
+  "required": [
+    "last_updated",
+    "servers",
+    "version"
+  ],
   "properties": {
     "last_updated": {
       "type": "string",
@@ -18,8 +22,7 @@
         "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
           "$ref": "#/$defs/server"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "remote_servers": {
       "type": "object",
@@ -28,8 +31,7 @@
         "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
           "$ref": "#/$defs/remote_server"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "groups": {
       "type": "array",
@@ -134,7 +136,10 @@
         "status": {
           "type": "string",
           "description": "Current status of the server (Active or Deprecated)",
-          "enum": ["Active", "Deprecated"]
+          "enum": [
+            "Active",
+            "Deprecated"
+          ]
         },
         "tags": {
           "type": "array",
@@ -161,7 +166,10 @@
         "tier": {
           "type": "string",
           "description": "Tier classification of the server, (Official or Community)",
-          "enum": ["Official", "Community"]
+          "enum": [
+            "Official",
+            "Community"
+          ]
         },
         "tools": {
           "type": "array",
@@ -183,16 +191,23 @@
         "transport": {
           "type": "string",
           "description": "Communication transport protocol used by the MCP server",
-          "enum": ["stdio", "sse", "streamable-http"],
+          "enum": [
+            "stdio",
+            "sse",
+            "streamable-http"
+          ],
           "default": "stdio"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "environment_variable": {
       "type": "object",
       "description": "Environment variable definition for MCP server configuration",
-      "required": ["name", "description", "required"],
+      "required": [
+        "name",
+        "description",
+        "required"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -219,8 +234,7 @@
           "type": "string",
           "description": "Value to use if the environment variable is not explicitly provided (only used for non-required variables)"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "permissions": {
       "type": "object",
@@ -255,8 +269,7 @@
           "description": "Whether the container should run in privileged mode. When true, the container has access to all host devices and capabilities. Use with extreme caution as this removes most security isolation.",
           "default": false
         }
-      },
-      "additionalProperties": false
+      }
     },
     "network_permissions": {
       "type": "object",
@@ -266,8 +279,7 @@
         "outbound": {
           "$ref": "#/$defs/outbound_permissions"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "outbound_permissions": {
       "type": "object",
@@ -307,8 +319,7 @@
           "description": "Whether to allow all outbound connections (insecure, use with caution)",
           "default": false
         }
-      },
-      "additionalProperties": false
+      }
     },
     "metadata": {
       "type": "object",
@@ -329,8 +340,7 @@
           "description": "Number of repository stars",
           "minimum": 0
         }
-      },
-      "additionalProperties": false
+      }
     },
     "provenance": {
       "type": "object",
@@ -340,7 +350,9 @@
           "type": "string",
           "description": "Certificate issuer for provenance verification",
           "format": "uri",
-          "examples": ["https://token.actions.githubusercontent.com"]
+          "examples": [
+            "https://token.actions.githubusercontent.com"
+          ]
         },
         "repository_uri": {
           "type": "string",
@@ -354,7 +366,11 @@
         "runner_environment": {
           "type": "string",
           "description": "Build environment where the server was built",
-          "examples": ["github-hosted", "gitlab-hosted", "self-hosted"]
+          "examples": [
+            "github-hosted",
+            "gitlab-hosted",
+            "self-hosted"
+          ]
         },
         "signer_identity": {
           "type": "string",
@@ -365,14 +381,16 @@
           "description": "Sigstore TUF repository host for provenance verification",
           "format": "hostname",
           "default": "tuf-repo-cdn.sigstore.dev",
-          "examples": ["tuf-repo.github.com", "tuf-repo-cdn.sigstore.dev"]
+          "examples": [
+            "tuf-repo.github.com",
+            "tuf-repo-cdn.sigstore.dev"
+          ]
         },
         "attestation": {
           "description": "Verified attestation information",
           "$ref": "#/$defs/verified_attestation"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "verified_attestation": {
       "type": "object",
@@ -390,13 +408,16 @@
         "predicate": {
           "description": "Attestation predicate data"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "header": {
       "type": "object",
       "description": "HTTP header definition for remote MCP server authentication",
-      "required": ["name", "description", "required"],
+      "required": [
+        "name",
+        "description",
+        "required"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -431,8 +452,7 @@
           },
           "uniqueItems": true
         }
-      },
-      "additionalProperties": false
+      }
     },
     "oauth_config": {
       "type": "object",
@@ -486,8 +506,7 @@
           "type": "string",
           "description": "OAuth 2.0 resource indicator (RFC 8707)"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "remote_server": {
       "type": "object",
@@ -532,17 +551,26 @@
         "tier": {
           "type": "string",
           "description": "Tier classification of the server (Official or Community)",
-          "enum": ["Official", "Community"]
+          "enum": [
+            "Official",
+            "Community"
+          ]
         },
         "status": {
           "type": "string",
           "description": "Current status of the server (Active or Deprecated)",
-          "enum": ["Active", "Deprecated"]
+          "enum": [
+            "Active",
+            "Deprecated"
+          ]
         },
         "transport": {
           "type": "string",
           "description": "Communication transport protocol used by the remote MCP server",
-          "enum": ["sse", "streamable-http"],
+          "enum": [
+            "sse",
+            "streamable-http"
+          ],
           "default": "sse"
         },
         "tools": {
@@ -604,13 +632,15 @@
           "description": "Custom user-defined metadata for the remote MCP server",
           "additionalProperties": true
         }
-      },
-      "additionalProperties": false
+      }
     },
     "group": {
       "type": "object",
       "description": "Group definition containing related MCP servers that can be deployed together",
-      "required": ["name", "description"],
+      "required": [
+        "name",
+        "description"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -632,8 +662,7 @@
             "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
               "$ref": "#/$defs/server"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "remote_servers": {
           "type": "object",
@@ -642,11 +671,9 @@
             "^[a-z0-9][a-z0-9-]+[a-z0-9]$": {
               "$ref": "#/$defs/remote_server"
             }
-          },
-          "additionalProperties": false
+          }
         }
-      },
-      "additionalProperties": false
+      }
     }
   }
 }

--- a/registry/types/schema_validation_test.go
+++ b/registry/types/schema_validation_test.go
@@ -230,7 +230,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 			errorContains: "description",
 		},
 		{
-			name: "invalid server name pattern",
+			name: "non-matching server name passes without additionalProperties restriction",
 			registryJSON: `{
 				"version": "1.0.0",
 				"last_updated": "2025-01-01T00:00:00Z",
@@ -245,8 +245,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 					}
 				}
 			}`,
-			expectError:   true,
-			errorContains: "Additional property",
+			expectError: false,
 		},
 		{
 			name: "valid remote server",


### PR DESCRIPTION
The following PR:
- Remove additionalProperties: false from all registry schema files so that unknown fields from newer upstream formats pass validation instead of causing errors
- Known fields are still strictly validated (types, patterns, enums, required checks)
- Update one test case that relied on additionalProperties rejection