### PR TITLE
Upgrade Go to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stacklok/toolhive-core
 
-go 1.25.8
+go 1.26
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
Upgrades the Go version in `go.mod` from 1.25.8 to 1.26.

CI workflows already use `go-version-file: 'go.mod'` so no workflow changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)