### PR TITLE
Embed external $ref schemas for offline validation

### DIFF
--- a/registry/types/data/server.schema.json
+++ b/registry/types/data/server.schema.json
@@ -1,0 +1,574 @@
+{
+  "$comment": "This file is auto-generated from docs/reference/api/openapi.yaml. Do not edit manually. Run 'make generate-schema' to update.",
+  "$id": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "$ref": "#/definitions/ServerDetail",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "Argument": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PositionalArgument"
+        },
+        {
+          "$ref": "#/definitions/NamedArgument"
+        }
+      ],
+      "description": "Warning: Arguments construct command-line parameters that may contain user-provided input. This creates potential command injection risks if clients execute commands in a shell environment. For example, a malicious argument value like ';rm -rf ~/Development' could execute dangerous commands. Clients should prefer non-shell execution methods (e.g., posix_spawn) when possible to eliminate injection risks entirely. Where not possible, clients should obtain consent from users or agents to run the resolved command before execution."
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic. Must be one of: image/png, image/jpeg, image/jpg, image/svg+xml, image/webp.",
+          "enum": [
+            "image/png",
+            "image/jpeg",
+            "image/jpg",
+            "image/svg+xml",
+            "image/webp"
+          ],
+          "example": "image/png",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used. Each string should be in WxH format (e.g., '48x48', '96x96') or 'any' for scalable formats like SVG. If not provided, the client should assume that the icon can be used at any size.",
+          "examples": [
+            [
+              "48x48",
+              "96x96"
+            ],
+            [
+              "any"
+            ]
+          ],
+          "items": {
+            "pattern": "^(\\d+x\\d+|any)$",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. Must be an HTTPS URL. Consumers SHOULD take steps to ensure URLs serving icons are from the same domain as the server or a trusted domain. Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain executable JavaScript.",
+          "example": "https://example.com/icon.png",
+          "format": "uri",
+          "maxLength": 255,
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. 'light' indicates the icon is designed to be used with a light background, and 'dark' indicates the icon is designed to be used with a dark background. If not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "light",
+            "dark"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Input": {
+      "properties": {
+        "choices": {
+          "description": "A list of possible values for the input. If provided, the user must select one of these values.",
+          "example": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "default": {
+          "description": "The default value for the input.  This should be a valid value for the input.  If you want to provide input examples or guidance, use the `placeholder` field instead.",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the input, which clients can use to provide context to the user.",
+          "type": "string"
+        },
+        "format": {
+          "default": "string",
+          "description": "Specifies the input format. Supported values include `filepath`, which should be interpreted as a file on the user's filesystem.\n\nWhen the input is converted to a string, booleans should be represented by the strings \"true\" and \"false\", and numbers should be represented as decimal values.",
+          "enum": [
+            "string",
+            "number",
+            "boolean",
+            "filepath"
+          ],
+          "type": "string"
+        },
+        "isRequired": {
+          "default": false,
+          "type": "boolean"
+        },
+        "isSecret": {
+          "default": false,
+          "description": "Indicates whether the input is a secret value (e.g., password, token). If true, clients should handle the value securely.",
+          "type": "boolean"
+        },
+        "placeholder": {
+          "description": "A placeholder for the input to be displaying during configuration. This is used to provide examples or guidance about the expected form or content of the input.",
+          "type": "string"
+        },
+        "value": {
+          "description": "The value for the input. If this is not set, the user may be prompted to provide a value. If a value is set, it should not be configurable by end users.\n\nIdentifiers wrapped in `{curly_braces}` will be replaced with the corresponding properties from the input `variables` map. If an identifier in braces is not found in `variables`, or if `variables` is not provided, the `{curly_braces}` substring should remain unchanged.\n",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "InputWithVariables": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Input"
+        },
+        {
+          "properties": {
+            "variables": {
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              },
+              "description": "A map of variable names to their values. Keys in the input `value` that are wrapped in `{curly_braces}` will be replaced with the corresponding variable values.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "KeyValueInput": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "name": {
+              "description": "Name of the header or environment variable.",
+              "example": "SOME_VARIABLE",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "LocalTransport": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/StdioTransport"
+        },
+        {
+          "$ref": "#/definitions/StreamableHttpTransport"
+        },
+        {
+          "$ref": "#/definitions/SseTransport"
+        }
+      ],
+      "description": "Transport protocol configuration for local/package context"
+    },
+    "NamedArgument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "properties": {
+            "isRepeated": {
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "The flag name, including any leading dashes.",
+              "example": "--port",
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "named"
+              ],
+              "example": "named",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A command-line `--flag={value}`."
+    },
+    "Package": {
+      "properties": {
+        "environmentVariables": {
+          "description": "A mapping of environment variables to be set when running the package.",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "fileSha256": {
+          "description": "SHA-256 hash of the package file for integrity verification. Required for MCPB packages and optional for other package types. Authors are responsible for generating correct SHA-256 hashes when creating server.json. If present, MCP clients must validate the downloaded file matches the hash before running packages to ensure file integrity.",
+          "example": "fe333e598595000ae021bd27117db32ec69af6987f507ba7a63c90638ff633ce",
+          "pattern": "^[a-f0-9]{64}$",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "Package identifier - either a package name (for registries) or URL (for direct downloads)",
+          "examples": [
+            "@modelcontextprotocol/server-brave-search",
+            "https://github.com/example/releases/download/v1.0.0/package.mcpb"
+          ],
+          "type": "string"
+        },
+        "packageArguments": {
+          "description": "A list of arguments to be passed to the package's binary.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
+        },
+        "registryBaseUrl": {
+          "description": "Base URL of the package registry",
+          "examples": [
+            "https://registry.npmjs.org",
+            "https://pypi.org",
+            "https://docker.io",
+            "https://api.nuget.org/v3/index.json",
+            "https://github.com",
+            "https://gitlab.com"
+          ],
+          "format": "uri",
+          "type": "string"
+        },
+        "registryType": {
+          "description": "Registry type indicating how to download packages (e.g., 'npm', 'pypi', 'oci', 'nuget', 'mcpb')",
+          "examples": [
+            "npm",
+            "pypi",
+            "oci",
+            "nuget",
+            "mcpb"
+          ],
+          "type": "string"
+        },
+        "runtimeArguments": {
+          "description": "A list of arguments to be passed to the package's runtime command (such as docker or npx). The `runtimeHint` field should be provided when `runtimeArguments` are present.",
+          "items": {
+            "$ref": "#/definitions/Argument"
+          },
+          "type": "array"
+        },
+        "runtimeHint": {
+          "description": "A hint to help clients determine the appropriate runtime for the package. This field should be provided when `runtimeArguments` are present.",
+          "examples": [
+            "npx",
+            "uvx",
+            "docker",
+            "dnx"
+          ],
+          "type": "string"
+        },
+        "transport": {
+          "$ref": "#/definitions/LocalTransport",
+          "description": "Transport protocol configuration for the package"
+        },
+        "version": {
+          "description": "Package version. Must be a specific version. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
+          "example": "1.0.2",
+          "minLength": 1,
+          "not": {
+            "const": "latest"
+          },
+          "type": "string"
+        }
+      },
+      "required": [
+        "registryType",
+        "identifier",
+        "transport"
+      ],
+      "type": "object"
+    },
+    "PositionalArgument": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/InputWithVariables"
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "valueHint"
+              ]
+            },
+            {
+              "required": [
+                "value"
+              ]
+            }
+          ],
+          "properties": {
+            "isRepeated": {
+              "default": false,
+              "description": "Whether the argument can be repeated multiple times in the command line.",
+              "type": "boolean"
+            },
+            "type": {
+              "enum": [
+                "positional"
+              ],
+              "example": "positional",
+              "type": "string"
+            },
+            "valueHint": {
+              "description": "An identifier for the positional argument. It is not part of the command line. It may be used by client configuration as a label identifying the argument. It is also used to identify the value in transport URL variable substitution.",
+              "example": "file_path",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "A positional input is a value inserted verbatim into the command line."
+    },
+    "RemoteTransport": {
+      "allOf": [
+        {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StreamableHttpTransport"
+            },
+            {
+              "$ref": "#/definitions/SseTransport"
+            }
+          ]
+        },
+        {
+          "properties": {
+            "variables": {
+              "additionalProperties": {
+                "$ref": "#/definitions/Input"
+              },
+              "description": "Configuration variables that can be referenced in URL template {curly_braces}. The key is the variable name, and the value defines the variable properties.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      ],
+      "description": "Transport protocol configuration for remote context - extends StreamableHttpTransport or SseTransport with variables"
+    },
+    "Repository": {
+      "description": "Repository metadata for the MCP server source code. Enables users and security experts to inspect the code, improving transparency.",
+      "properties": {
+        "id": {
+          "description": "Repository identifier from the hosting service (e.g., GitHub repo ID). Owned and determined by the source forge. Should remain stable across repository renames and may be used to detect repository resurrection attacks - if a repository is deleted and recreated, the ID should change. For GitHub, use: gh api repos/\u003cowner\u003e/\u003crepo\u003e --jq '.id'",
+          "example": "b94b5f7e-c7c6-d760-2c78-a5e9b8a5b8c9",
+          "type": "string"
+        },
+        "source": {
+          "description": "Repository hosting service identifier. Used by registries to determine validation and API access methods.",
+          "example": "github",
+          "type": "string"
+        },
+        "subfolder": {
+          "description": "Optional relative path from repository root to the server location within a monorepo or nested package structure. Must be a clean relative path.",
+          "example": "src/everything",
+          "type": "string"
+        },
+        "url": {
+          "description": "Repository URL for browsing source code. Should support both web browsing and git clone operations.",
+          "example": "https://github.com/modelcontextprotocol/servers",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "source"
+      ],
+      "type": "object"
+    },
+    "ServerDetail": {
+      "description": "Schema for a static representation of an MCP server. Used in various contexts related to discovery, installation, and configuration.",
+      "properties": {
+        "$schema": {
+          "description": "JSON Schema URI for this server.json format",
+          "example": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+          "format": "uri",
+          "type": "string"
+        },
+        "_meta": {
+          "description": "Extension metadata using reverse DNS namespacing for vendor-specific data",
+          "properties": {
+            "io.modelcontextprotocol.registry/publisher-provided": {
+              "additionalProperties": true,
+              "description": "Publisher-provided metadata for downstream registries",
+              "example": {
+                "buildInfo": {
+                  "commit": "abc123def456",
+                  "pipelineId": "build-789",
+                  "timestamp": "2023-12-01T10:30:00Z"
+                },
+                "tool": "publisher-cli",
+                "version": "1.2.3"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "description": {
+          "description": "Clear human-readable explanation of server functionality. Should focus on capabilities, not implementation details.",
+          "example": "MCP server providing weather data and forecasts via OpenWeatherMap API",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface. Clients that support rendering icons MUST support at least the following MIME types: image/png and image/jpeg (safe, universal compatibility). Clients SHOULD also support: image/svg+xml (scalable but requires security precautions) and image/webp (modern, efficient format).",
+          "items": {
+            "$ref": "#/definitions/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Server name in reverse-DNS format. Must contain exactly one forward slash separating namespace from server name.",
+          "example": "io.github.user/weather",
+          "maxLength": 200,
+          "minLength": 3,
+          "pattern": "^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$",
+          "type": "string"
+        },
+        "packages": {
+          "items": {
+            "$ref": "#/definitions/Package"
+          },
+          "type": "array"
+        },
+        "remotes": {
+          "items": {
+            "$ref": "#/definitions/RemoteTransport"
+          },
+          "type": "array"
+        },
+        "repository": {
+          "$ref": "#/definitions/Repository",
+          "description": "Optional repository metadata for the MCP server source code. Recommended for transparency and security inspection."
+        },
+        "title": {
+          "description": "Optional human-readable title or display name for the MCP server. MCP subregistries or clients MAY choose to use this for display purposes.",
+          "example": "Weather API",
+          "maxLength": 100,
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "description": "Version string for this server. SHOULD follow semantic versioning (e.g., '1.0.2', '2.1.0-alpha'). Equivalent of Implementation.version in MCP specification. Non-semantic versions are allowed but may not sort predictably. Version ranges are rejected (e.g., '^1.2.3', '~1.2.3', '\u003e=1.2.3', '1.x', '1.*').",
+          "example": "1.0.2",
+          "maxLength": 255,
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "Optional URL to the server's homepage, documentation, or project website. This provides a central link for users to learn more about the server. Particularly useful when the server has custom installation instructions or setup requirements.",
+          "example": "https://modelcontextprotocol.io/examples",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "version"
+      ],
+      "type": "object"
+    },
+    "SseTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "sse"
+          ],
+          "example": "sse",
+          "type": "string"
+        },
+        "url": {
+          "description": "Server-Sent Events endpoint URL template. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
+          "example": "https://mcp-fs.example.com/sse",
+          "pattern": "^https?://[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    },
+    "StdioTransport": {
+      "properties": {
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "stdio"
+          ],
+          "example": "stdio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "StreamableHttpTransport": {
+      "properties": {
+        "headers": {
+          "description": "HTTP headers to include",
+          "items": {
+            "$ref": "#/definitions/KeyValueInput"
+          },
+          "type": "array"
+        },
+        "type": {
+          "description": "Transport type",
+          "enum": [
+            "streamable-http"
+          ],
+          "example": "streamable-http",
+          "type": "string"
+        },
+        "url": {
+          "description": "URL template for the streamable-http transport. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
+          "example": "https://api.example.com/mcp",
+          "pattern": "^https?://[^\\s]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "url"
+      ],
+      "type": "object"
+    }
+  },
+  "title": "server.json defining a Model Context Protocol (MCP) server"
+}

--- a/registry/types/schema_validation.go
+++ b/registry/types/schema_validation.go
@@ -9,12 +9,46 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/xeipuuv/gojsonschema"
 )
 
-//go:embed data/toolhive-legacy-registry.schema.json data/upstream-registry.schema.json data/publisher-provided.schema.json data/skill.schema.json
+//go:embed data/toolhive-legacy-registry.schema.json data/upstream-registry.schema.json data/publisher-provided.schema.json data/skill.schema.json data/server.schema.json
 var embeddedSchemaFS embed.FS
+
+// referencedSchemas lists embedded schema files that declare an $id matching
+// a $ref in other schemas. They are preloaded into every SchemaLoader so the
+// validator never needs to fetch them over the network.
+var referencedSchemas = []string{
+	"data/server.schema.json",
+	"data/skill.schema.json",
+}
+
+// preloadedSchemaLoaders caches the raw bytes of each referenced schema,
+// keyed by its embedded file path. Built once via preloadOnce.
+var (
+	preloadOnce          sync.Once
+	preloadedSchemaBytes [][]byte
+	preloadErr           error
+)
+
+// ensurePreloaded reads the referenced schema files once and caches their
+// bytes for reuse across every call to validateAgainstSchema.
+func ensurePreloaded() error {
+	preloadOnce.Do(func() {
+		preloadedSchemaBytes = make([][]byte, 0, len(referencedSchemas))
+		for _, path := range referencedSchemas {
+			data, err := embeddedSchemaFS.ReadFile(path)
+			if err != nil {
+				preloadErr = fmt.Errorf("failed to read embedded referenced schema %s: %w", path, err)
+				return
+			}
+			preloadedSchemaBytes = append(preloadedSchemaBytes, data)
+		}
+	})
+	return preloadErr
+}
 
 // Validate validates the Registry against the legacy ToolHive registry schema.
 func (r *Registry) Validate() error {
@@ -98,16 +132,38 @@ func ValidateServerJSON(serverData []byte, validateExtensions bool) error {
 }
 
 // validateAgainstSchema validates data against a named embedded schema file.
+// Referenced schemas (server.schema.json, skill.schema.json) are preloaded
+// into the schema loader so the validator never makes HTTP requests to
+// resolve external $ref URLs.
 func validateAgainstSchema(data []byte, schemaFile, errPrefix string) error {
+	if err := ensurePreloaded(); err != nil {
+		return fmt.Errorf("%s: %w", errPrefix, err)
+	}
+
 	schemaData, err := embeddedSchemaFS.ReadFile(schemaFile)
 	if err != nil {
 		return fmt.Errorf("failed to read embedded schema %s: %w", schemaFile, err)
 	}
 
-	result, err := gojsonschema.Validate(
-		gojsonschema.NewBytesLoader(schemaData),
-		gojsonschema.NewBytesLoader(data),
-	)
+	sl := gojsonschema.NewSchemaLoader()
+	for i, refPath := range referencedSchemas {
+		// Skip preloading a schema that is the same file being compiled;
+		// Compile will register it via its $id and a duplicate would
+		// cause a "Reference already exists" error.
+		if refPath == schemaFile {
+			continue
+		}
+		if err := sl.AddSchemas(gojsonschema.NewBytesLoader(preloadedSchemaBytes[i])); err != nil {
+			return fmt.Errorf("%s: failed to preload referenced schema: %w", errPrefix, err)
+		}
+	}
+
+	compiled, err := sl.Compile(gojsonschema.NewBytesLoader(schemaData))
+	if err != nil {
+		return fmt.Errorf("%s: %w", errPrefix, err)
+	}
+
+	result, err := compiled.Validate(gojsonschema.NewBytesLoader(data))
 	if err != nil {
 		return fmt.Errorf("%s: %w", errPrefix, err)
 	}

--- a/registry/types/schema_validation_test.go
+++ b/registry/types/schema_validation_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	upstreamv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
@@ -1738,6 +1739,83 @@ func TestUpstreamRegistrySchemaVersionSync(t *testing.T) {
 						groupSchemaDate, expectedDate)
 				}
 			}
+		}
+	}
+}
+
+// findExternalRefs recursively walks a parsed JSON value and collects all
+// "$ref" string values that start with "http://" or "https://".
+func findExternalRefs(v any) []string {
+	var refs []string
+	switch val := v.(type) {
+	case map[string]any:
+		for key, child := range val {
+			if key == "$ref" {
+				if s, ok := child.(string); ok {
+					if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+						refs = append(refs, s)
+					}
+				}
+				continue
+			}
+			refs = append(refs, findExternalRefs(child)...)
+		}
+	case []any:
+		for _, item := range val {
+			refs = append(refs, findExternalRefs(item)...)
+		}
+	}
+	return refs
+}
+
+// TestExternalRefsHaveEmbeddedSchemas ensures that every external $ref URL
+// found in the embedded schema files has a corresponding $id in one of the
+// other embedded schemas. This prevents silent fallback to HTTP fetching when
+// a referenced schema is not vendored locally.
+func TestExternalRefsHaveEmbeddedSchemas(t *testing.T) {
+	t.Parallel()
+
+	entries, err := embeddedSchemaFS.ReadDir("data")
+	require.NoError(t, err, "failed to read embedded schema directory")
+
+	// First pass: collect $id values from all schema files.
+	idSet := make(map[string]bool)
+	// Also store parsed schemas keyed by file name for the second pass.
+	type schemaEntry struct {
+		name   string
+		parsed any
+	}
+	var schemas []schemaEntry
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".schema.json") {
+			continue
+		}
+		filePath := "data/" + entry.Name()
+		data, readErr := embeddedSchemaFS.ReadFile(filePath)
+		require.NoError(t, readErr, "failed to read embedded schema file %s", filePath)
+
+		var parsed any
+		require.NoError(t, json.Unmarshal(data, &parsed), "failed to parse %s", filePath)
+
+		schemas = append(schemas, schemaEntry{name: filePath, parsed: parsed})
+
+		// Extract $id if present at the top level.
+		if obj, ok := parsed.(map[string]any); ok {
+			if id, ok := obj["$id"].(string); ok {
+				idSet[id] = true
+			}
+		}
+	}
+
+	// Second pass: find all external $ref URLs and verify each has a matching $id.
+	for _, s := range schemas {
+		refs := findExternalRefs(s.parsed)
+		for _, ref := range refs {
+			assert.True(t, idSet[ref],
+				"Schema file %q has external $ref %q but no embedded schema has a matching $id.\n"+
+					"To fix: vendor the referenced schema into registry/types/data/ and add it to the go:embed directive.",
+				s.name, ref)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Vendor the MCP `server.schema.json` into `registry/types/data/` so all `$ref` resolution in JSON schema validation stays local
- Switch `validateAgainstSchema` from `gojsonschema.Validate()` to `SchemaLoader.AddSchemas()` + `Compile()`, preloading referenced schemas by their `$id`
- Add `TestExternalRefsHaveEmbeddedSchemas` CI guard that fails if any embedded schema has an external `$ref` without a matching vendored `$id`

**Problem**: `upstream-registry.schema.json` contains `$ref` URLs pointing to `static.modelcontextprotocol.io` and `raw.githubusercontent.com`. The `gojsonschema` library follows these over HTTP during validation, causing timeout failures in network-restricted deployments (e.g. environments with egress network policies).

**Fix**: All referenced schemas are now embedded and preloaded into the `SchemaLoader`, so validation never makes HTTP requests. The CI test ensures this invariant holds as schemas evolve.

## Test plan

- [x] Existing `TestUpstreamRegistrySchemaVersionSync` passes (schema version alignment)
- [x] New `TestExternalRefsHaveEmbeddedSchemas` passes (all external `$ref` URLs resolve locally)
- [x] Full `task` suite passes (lint + all tests)
- [ ] Verify in a network-restricted environment that sync no longer fails with timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)