### PR TITLE
Add stateless field to registry server types

### DIFF
--- a/registry/converters/converters_test.go
+++ b/registry/converters/converters_test.go
@@ -882,6 +882,76 @@ func TestRoundTrip_RemoteServerMetadata(t *testing.T) {
 	assert.Len(t, result.ToolDefinitions, len(original.ToolDefinitions))
 }
 
+func TestRoundTrip_StatelessField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("remote server with stateless=true", func(t *testing.T) {
+		t.Parallel()
+
+		original := &registry.RemoteServerMetadata{
+			BaseServerMetadata: registry.BaseServerMetadata{
+				Description: "Stateless remote server",
+				Transport:   "streamable-http",
+				Status:      "active",
+				Tier:        "Official",
+				Tools:       []string{"tool1"},
+				Tags:        []string{"stateless"},
+				Stateless:   true,
+			},
+			URL: "https://api.example.com/mcp",
+		}
+
+		serverJSON, err := RemoteServerMetadataToServerJSON("stateless-remote", original)
+		require.NoError(t, err)
+
+		result, err := ServerJSONToRemoteServerMetadata(serverJSON)
+		require.NoError(t, err)
+
+		assert.True(t, result.Stateless, "Stateless field should be preserved through round-trip")
+		assert.True(t, result.GetStateless(), "GetStateless() should return true")
+	})
+
+	t.Run("remote server with stateless=false (default)", func(t *testing.T) {
+		t.Parallel()
+
+		original := createTestRemoteServerMetadata()
+		assert.False(t, original.Stateless, "test fixture should default to false")
+
+		serverJSON, err := RemoteServerMetadataToServerJSON("stateful-remote", original)
+		require.NoError(t, err)
+
+		result, err := ServerJSONToRemoteServerMetadata(serverJSON)
+		require.NoError(t, err)
+
+		assert.False(t, result.Stateless, "Stateless field should remain false")
+	})
+
+	t.Run("image server with stateless=true", func(t *testing.T) {
+		t.Parallel()
+
+		original := &registry.ImageMetadata{
+			BaseServerMetadata: registry.BaseServerMetadata{
+				Description: "Stateless container server",
+				Transport:   "streamable-http",
+				Status:      "active",
+				Tier:        "Official",
+				Tools:       []string{"tool1"},
+				Tags:        []string{"stateless"},
+				Stateless:   true,
+			},
+			Image: "ghcr.io/test/stateless:latest",
+		}
+
+		serverJSON, err := ImageMetadataToServerJSON("stateless-image", original)
+		require.NoError(t, err)
+
+		result, err := ServerJSONToImageMetadata(serverJSON)
+		require.NoError(t, err)
+
+		assert.True(t, result.Stateless, "Stateless field should be preserved through round-trip")
+	})
+}
+
 func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 	t.Parallel()
 
@@ -893,6 +963,7 @@ func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 			RepositoryURL: "https://github.com/test/full",
 			Status:        "active",
 			Tier:          "Official",
+			Stateless:     true,
 			Tools:         []string{"tool1", "tool2", "tool3"},
 			Tags:          []string{"tag1", "tag2"},
 			Metadata: &registry.Metadata{
@@ -937,6 +1008,7 @@ func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 	assert.Equal(t, original.Tools, result.Tools)
 	assert.Equal(t, original.Tags, result.Tags)
 	assert.Equal(t, original.TargetPort, result.TargetPort)
+	assert.Equal(t, original.Stateless, result.Stateless)
 
 	require.Len(t, result.EnvVars, len(original.EnvVars))
 	for i := range original.EnvVars {

--- a/registry/converters/converters_test.go
+++ b/registry/converters/converters_test.go
@@ -882,6 +882,76 @@ func TestRoundTrip_RemoteServerMetadata(t *testing.T) {
 	assert.Len(t, result.ToolDefinitions, len(original.ToolDefinitions))
 }
 
+func TestRoundTrip_StatelessField(t *testing.T) {
+	t.Parallel()
+
+	t.Run("remote server with stateless=true", func(t *testing.T) {
+		t.Parallel()
+
+		original := &registry.RemoteServerMetadata{
+			BaseServerMetadata: registry.BaseServerMetadata{
+				Description: "Stateless remote server",
+				Transport:   model.TransportTypeStreamableHTTP,
+				Status:      defaultStatus,
+				Tier:        testTier,
+				Tools:       []string{testToolName},
+				Tags:        []string{"stateless"},
+				Stateless:   true,
+			},
+			URL: testRemoteURL,
+		}
+
+		serverJSON, err := RemoteServerMetadataToServerJSON("stateless-remote", original)
+		require.NoError(t, err)
+
+		result, err := ServerJSONToRemoteServerMetadata(serverJSON)
+		require.NoError(t, err)
+
+		assert.True(t, result.Stateless, "Stateless field should be preserved through round-trip")
+		assert.True(t, result.GetStateless(), "GetStateless() should return true")
+	})
+
+	t.Run("remote server with stateless=false (default)", func(t *testing.T) {
+		t.Parallel()
+
+		original := createTestRemoteServerMetadata()
+		assert.False(t, original.Stateless, "test fixture should default to false")
+
+		serverJSON, err := RemoteServerMetadataToServerJSON("stateful-remote", original)
+		require.NoError(t, err)
+
+		result, err := ServerJSONToRemoteServerMetadata(serverJSON)
+		require.NoError(t, err)
+
+		assert.False(t, result.Stateless, "Stateless field should remain false")
+	})
+
+	t.Run("image server with stateless=true", func(t *testing.T) {
+		t.Parallel()
+
+		original := &registry.ImageMetadata{
+			BaseServerMetadata: registry.BaseServerMetadata{
+				Description: "Stateless container server",
+				Transport:   model.TransportTypeStreamableHTTP,
+				Status:      defaultStatus,
+				Tier:        testTier,
+				Tools:       []string{testToolName},
+				Tags:        []string{"stateless"},
+				Stateless:   true,
+			},
+			Image: testImageRef,
+		}
+
+		serverJSON, err := ImageMetadataToServerJSON("stateless-image", original)
+		require.NoError(t, err)
+
+		result, err := ServerJSONToImageMetadata(serverJSON)
+		require.NoError(t, err)
+
+		assert.True(t, result.Stateless, "Stateless field should be preserved through round-trip")
+	})
+}
+
 func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 	t.Parallel()
 
@@ -893,6 +963,7 @@ func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 			RepositoryURL: "https://github.com/test/full",
 			Status:        defaultStatus,
 			Tier:          testTier,
+			Stateless:     true,
 			Tools:         []string{testToolName, testToolNameAlt, "tool3"},
 			Tags:          []string{"tag1", "tag2"},
 			Metadata: &registry.Metadata{
@@ -937,6 +1008,7 @@ func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 	assert.Equal(t, original.Tools, result.Tools)
 	assert.Equal(t, original.Tags, result.Tags)
 	assert.Equal(t, original.TargetPort, result.TargetPort)
+	assert.Equal(t, original.Stateless, result.Stateless)
 
 	require.Len(t, result.EnvVars, len(original.EnvVars))
 	for i := range original.EnvVars {

--- a/registry/converters/toolhive_to_upstream.go
+++ b/registry/converters/toolhive_to_upstream.go
@@ -217,6 +217,7 @@ func createImageExtensions(imageMetadata *registry.ImageMetadata) map[string]int
 		Provenance:      imageMetadata.Provenance,
 		DockerTags:      imageMetadata.DockerTags,
 		ProxyPort:       imageMetadata.ProxyPort,
+		Stateless:       imageMetadata.Stateless,
 	}
 	return buildPublisherExtensionsMap(ext, imageMetadata.Image)
 }
@@ -236,6 +237,7 @@ func createRemoteExtensions(remoteMetadata *registry.RemoteServerMetadata) map[s
 		OAuthConfig:     remoteMetadata.OAuthConfig,
 		EnvVars:         remoteMetadata.EnvVars,
 		ProxyPort:       remoteMetadata.ProxyPort,
+		Stateless:       remoteMetadata.Stateless,
 	}
 	return buildPublisherExtensionsMap(ext, remoteMetadata.URL)
 }

--- a/registry/converters/toolhive_to_upstream.go
+++ b/registry/converters/toolhive_to_upstream.go
@@ -224,6 +224,7 @@ func createImageExtensions(imageMetadata *registry.ImageMetadata) map[string]int
 		Provenance:      imageMetadata.Provenance,
 		DockerTags:      imageMetadata.DockerTags,
 		ProxyPort:       imageMetadata.ProxyPort,
+		Stateless:       imageMetadata.Stateless,
 	}
 	return buildPublisherExtensionsMap(ext, imageMetadata.Image)
 }
@@ -243,6 +244,7 @@ func createRemoteExtensions(remoteMetadata *registry.RemoteServerMetadata) map[s
 		OAuthConfig:     remoteMetadata.OAuthConfig,
 		EnvVars:         remoteMetadata.EnvVars,
 		ProxyPort:       remoteMetadata.ProxyPort,
+		Stateless:       remoteMetadata.Stateless,
 	}
 	return buildPublisherExtensionsMap(ext, remoteMetadata.URL)
 }

--- a/registry/converters/upstream_to_toolhive.go
+++ b/registry/converters/upstream_to_toolhive.go
@@ -281,6 +281,7 @@ func applyBaseExtensions(ext *registry.ServerExtensions, base *registry.BaseServ
 	base.ToolDefinitions = ext.ToolDefinitions
 	base.Metadata = ext.Metadata
 	base.CustomMetadata = ext.CustomMetadata
+	base.Stateless = ext.Stateless
 }
 
 // extractImageExtensions extracts publisher-provided extensions into ImageMetadata

--- a/registry/types/data/publisher-provided.schema.json
+++ b/registry/types/data/publisher-provided.schema.json
@@ -105,6 +105,11 @@
           "minimum": 1,
           "maximum": 65535
         },
+        "stateless": {
+          "type": "boolean",
+          "description": "Whether the server only supports POST requests (no SSE/GET). When true, the proxy returns 405 for GET and uses POST-based health checks.",
+          "default": false
+        },
         "oauth_config": {
           "description": "OAuth/OIDC configuration for remote servers",
           "$ref": "#/$defs/oauth_config"

--- a/registry/types/data/publisher-provided.schema.json
+++ b/registry/types/data/publisher-provided.schema.json
@@ -105,6 +105,11 @@
           "minimum": 1,
           "maximum": 65535
         },
+        "stateless": {
+          "type": "boolean",
+          "description": "Whether the server only supports POST requests (no SSE/GET).",
+          "default": false
+        },
         "oauth_config": {
           "description": "OAuth/OIDC configuration for remote servers",
           "$ref": "#/$defs/oauth_config"

--- a/registry/types/data/toolhive-legacy-registry.schema.json
+++ b/registry/types/data/toolhive-legacy-registry.schema.json
@@ -197,6 +197,11 @@
             "streamable-http"
           ],
           "default": "stdio"
+        },
+        "stateless": {
+          "type": "boolean",
+          "description": "Whether the server only supports POST requests (no SSE/GET). When true, the proxy returns 405 for GET and uses POST-based health checks.",
+          "default": false
         }
       }
     },
@@ -572,6 +577,11 @@
             "streamable-http"
           ],
           "default": "sse"
+        },
+        "stateless": {
+          "type": "boolean",
+          "description": "Whether the server only supports POST requests (no SSE/GET). When true, the proxy returns 405 for GET and uses POST-based health checks.",
+          "default": false
         },
         "tools": {
           "type": "array",

--- a/registry/types/publisher_provided_types.go
+++ b/registry/types/publisher_provided_types.go
@@ -18,10 +18,10 @@ import (
 //   - For remote servers: keyed by URL (e.g., "https://api.example.com/mcp")
 //
 // Container servers may use: Status, Tier, Tools, Tags, Metadata, CustomMetadata,
-// Permissions, Args, Provenance, DockerTags, ProxyPort, ToolDefinitions
+// Permissions, Args, Provenance, DockerTags, ProxyPort, Stateless, ToolDefinitions
 //
 // Remote servers may use: Status, Tier, Tools, Tags, Metadata, CustomMetadata,
-// OAuthConfig, EnvVars, ProxyPort, ToolDefinitions
+// OAuthConfig, EnvVars, ProxyPort, Stateless, ToolDefinitions
 type ServerExtensions struct {
 	// Status indicates whether the server is active or deprecated (required)
 	Status string `json:"status" yaml:"status"`
@@ -57,6 +57,9 @@ type ServerExtensions struct {
 	// ProxyPort is the HTTP proxy port (1-65535). Applies to both container-based
 	// and remote servers.
 	ProxyPort int `json:"proxy_port,omitempty" yaml:"proxy_port,omitempty"`
+	// Stateless indicates the server only supports POST (no SSE/GET).
+	// Applies to both container-based and remote servers.
+	Stateless bool `json:"stateless,omitempty" yaml:"stateless,omitempty"`
 
 	// Remote server-specific fields (only for servers keyed by URL)
 

--- a/registry/types/registry_types.go
+++ b/registry/types/registry_types.go
@@ -66,6 +66,8 @@ type BaseServerMetadata struct {
 	// For containers: stdio, sse, or streamable-http
 	// For remote servers: sse or streamable-http (stdio not supported)
 	Transport string `json:"transport" yaml:"transport"`
+	// Stateless indicates the server only supports POST (no SSE/GET)
+	Stateless bool `json:"stateless,omitempty" yaml:"stateless,omitempty"`
 	// Tools is a list of tool names provided by this MCP server
 	Tools []string `json:"tools" yaml:"tools"`
 	// Metadata contains additional information about the server such as popularity metrics
@@ -291,6 +293,8 @@ type ServerMetadata interface {
 	GetStatus() string
 	// GetTransport returns the server transport
 	GetTransport() string
+	// GetStateless returns whether the server is stateless (POST-only, no SSE/GET)
+	GetStateless() bool
 	// GetTools returns the list of tools provided by the server
 	GetTools() []string
 	// GetMetadata returns the server metadata
@@ -360,6 +364,14 @@ func (b *BaseServerMetadata) GetTransport() string {
 		return ""
 	}
 	return b.Transport
+}
+
+// GetStateless returns whether the server is stateless (POST-only, no SSE/GET)
+func (b *BaseServerMetadata) GetStateless() bool {
+	if b == nil {
+		return false
+	}
+	return b.Stateless
 }
 
 // GetTools returns the list of tools provided by the server

--- a/registry/types/registry_types.go
+++ b/registry/types/registry_types.go
@@ -59,6 +59,8 @@ type BaseServerMetadata struct {
 	// For containers: stdio, sse, or streamable-http
 	// For remote servers: sse or streamable-http (stdio not supported)
 	Transport string `json:"transport" yaml:"transport"`
+	// Stateless indicates the server only supports POST (no SSE/GET)
+	Stateless bool `json:"stateless,omitempty" yaml:"stateless,omitempty"`
 	// Tools is a list of tool names provided by this MCP server
 	Tools []string `json:"tools" yaml:"tools"`
 	// Metadata contains additional information about the server such as popularity metrics
@@ -284,6 +286,8 @@ type ServerMetadata interface {
 	GetStatus() string
 	// GetTransport returns the server transport
 	GetTransport() string
+	// GetStateless returns whether the server is stateless (POST-only, no SSE/GET)
+	GetStateless() bool
 	// GetTools returns the list of tools provided by the server
 	GetTools() []string
 	// GetMetadata returns the server metadata
@@ -353,6 +357,14 @@ func (b *BaseServerMetadata) GetTransport() string {
 		return ""
 	}
 	return b.Transport
+}
+
+// GetStateless returns whether the server is stateless (POST-only, no SSE/GET)
+func (b *BaseServerMetadata) GetStateless() bool {
+	if b == nil {
+		return false
+	}
+	return b.Stateless
 }
 
 // GetTools returns the list of tools provided by the server

--- a/registry/types/registry_types_test.go
+++ b/registry/types/registry_types_test.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -251,6 +252,7 @@ func TestRegistry_ServerMetadataInterface(t *testing.T) {
 	assert.Nil(t, sa.GetToolDefinitions())
 	assert.Nil(t, sa.GetCustomMetadata())
 	assert.Nil(t, sa.GetMetadata())
+	assert.False(t, sa.GetStateless()) // not set in fixture
 	assert.False(t, sa.IsRemote())
 	require.Len(t, sa.GetEnvVars(), 1)
 	assert.Equal(t, "API_KEY", sa.GetEnvVars()[0].Name)
@@ -291,4 +293,85 @@ func TestMetadata_ParsedTime(t *testing.T) {
 	m := &Metadata{LastUpdated: "not-a-date"}
 	_, err = m.ParsedTime()
 	assert.Error(t, err)
+}
+
+func TestStateless_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const yamlData = `
+version: "1.0.0"
+last_updated: "2024-06-01T00:00:00Z"
+servers: {}
+remote_servers:
+  stateless-remote:
+    name: stateless-remote
+    description: A stateless remote server
+    tier: Community
+    status: Active
+    transport: streamable-http
+    stateless: true
+    url: https://api.example.com/mcp
+    tools:
+      - tool1
+`
+	var reg Registry
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &reg))
+
+	rs := reg.RemoteServers["stateless-remote"]
+	require.NotNil(t, rs)
+	assert.True(t, rs.Stateless, "Stateless should be true after YAML unmarshal")
+	assert.True(t, rs.GetStateless(), "GetStateless() should return true")
+
+	// Verify through ServerMetadata interface
+	srv, ok := reg.GetServerByName("stateless-remote")
+	require.True(t, ok)
+	assert.True(t, srv.GetStateless())
+
+	// Verify default (omitted) is false via the shared fixture
+	sharedReg := parseTestRegistry(t)
+	ra := sharedReg.RemoteServers["remote-a"]
+	require.NotNil(t, ra)
+	assert.False(t, ra.Stateless, "Stateless should default to false when omitted")
+}
+
+func TestStateless_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := &RemoteServerMetadata{
+		BaseServerMetadata: BaseServerMetadata{
+			Name:        "test",
+			Description: "test server",
+			Transport:   "streamable-http",
+			Stateless:   true,
+			Status:      "active",
+			Tier:        "Official",
+			Tools:       []string{"tool1"},
+		},
+		URL: "https://example.com/mcp",
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded RemoteServerMetadata
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.True(t, decoded.Stateless)
+
+	// Verify omitempty: false value should not appear in JSON
+	falseOriginal := &RemoteServerMetadata{
+		BaseServerMetadata: BaseServerMetadata{
+			Name:      "test2",
+			Stateless: false,
+		},
+	}
+	falseData, err := json.Marshal(falseOriginal)
+	require.NoError(t, err)
+	assert.NotContains(t, string(falseData), "stateless")
+}
+
+func TestStateless_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var b *BaseServerMetadata
+	assert.False(t, b.GetStateless(), "nil receiver should return false")
 }

--- a/registry/types/registry_types_test.go
+++ b/registry/types/registry_types_test.go
@@ -4,6 +4,7 @@
 package registry
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -251,6 +252,7 @@ func TestRegistry_ServerMetadataInterface(t *testing.T) {
 	assert.Nil(t, sa.GetToolDefinitions())
 	assert.Nil(t, sa.GetCustomMetadata())
 	assert.Nil(t, sa.GetMetadata())
+	assert.False(t, sa.GetStateless()) // not set in fixture
 	assert.False(t, sa.IsRemote())
 	require.Len(t, sa.GetEnvVars(), 1)
 	assert.Equal(t, "API_KEY", sa.GetEnvVars()[0].Name)
@@ -291,4 +293,85 @@ func TestMetadata_ParsedTime(t *testing.T) {
 	m := &Metadata{LastUpdated: "not-a-date"}
 	_, err = m.ParsedTime()
 	assert.Error(t, err)
+}
+
+func TestStateless_YAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const yamlData = `
+version: "1.0.0"
+last_updated: "2024-06-01T00:00:00Z"
+servers: {}
+remote_servers:
+  stateless-remote:
+    name: stateless-remote
+    description: A stateless remote server
+    tier: Community
+    status: Active
+    transport: streamable-http
+    stateless: true
+    url: https://api.example.com/mcp
+    tools:
+      - tool1
+`
+	var reg Registry
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &reg))
+
+	rs := reg.RemoteServers["stateless-remote"]
+	require.NotNil(t, rs)
+	assert.True(t, rs.Stateless, "Stateless should be true after YAML unmarshal")
+	assert.True(t, rs.GetStateless(), "GetStateless() should return true")
+
+	// Verify through ServerMetadata interface
+	srv, ok := reg.GetServerByName("stateless-remote")
+	require.True(t, ok)
+	assert.True(t, srv.GetStateless())
+
+	// Verify default (omitted) is false via the shared fixture
+	sharedReg := parseTestRegistry(t)
+	ra := sharedReg.RemoteServers["remote-a"]
+	require.NotNil(t, ra)
+	assert.False(t, ra.Stateless, "Stateless should default to false when omitted")
+}
+
+func TestStateless_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := &RemoteServerMetadata{
+		BaseServerMetadata: BaseServerMetadata{
+			Name:        "test",
+			Description: "test server",
+			Transport:   "streamable-http",
+			Stateless:   true,
+			Status:      testStatusActive,
+			Tier:        "Official",
+			Tools:       []string{"tool1"},
+		},
+		URL: "https://example.com/mcp",
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded RemoteServerMetadata
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.True(t, decoded.Stateless)
+
+	// Verify omitempty: false value should not appear in JSON
+	falseOriginal := &RemoteServerMetadata{
+		BaseServerMetadata: BaseServerMetadata{
+			Name:      "test2",
+			Stateless: false,
+		},
+	}
+	falseData, err := json.Marshal(falseOriginal)
+	require.NoError(t, err)
+	assert.NotContains(t, string(falseData), "stateless")
+}
+
+func TestStateless_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var b *BaseServerMetadata
+	assert.False(t, b.GetStateless(), "nil receiver should return false")
 }

--- a/registry/types/schema_validation_test.go
+++ b/registry/types/schema_validation_test.go
@@ -1085,7 +1085,7 @@ func TestServerExtensions_Validate(t *testing.T) {
 		},
 		{
 			name:        "invalid extensions - non-empty struct fails schema structure",
-			extensions:  &ServerExtensions{Status: "active", Tier: "Official"},
+			extensions:  &ServerExtensions{Status: testStatusActive, Tier: "Official"},
 			expectError: true,
 		},
 	}

--- a/registry/types/test_constants_test.go
+++ b/registry/types/test_constants_test.go
@@ -7,6 +7,7 @@ const (
 	testVersion       = "1.0.0"
 	testServerName    = "server-a"
 	testRemoteName    = "remote-a"
+	testStatusActive  = "active"
 	errKeyVersion     = "version"
 	errKeyLastUpdated = "last_updated"
 	errKeyDescription = "description"

--- a/registry/types/upstream_registry_test.go
+++ b/registry/types/upstream_registry_test.go
@@ -158,7 +158,7 @@ func TestUpstreamRegistry_WithSkills(t *testing.T) {
 					Name:        "pdf-processor",
 					Description: "Extract text and tables from PDF files",
 					Version:     testVersion,
-					Status:      "active",
+					Status:      testStatusActive,
 					Packages: []SkillPackage{
 						{
 							RegistryType: "oci",


### PR DESCRIPTION
## Summary

- Registry entries cannot declare that a server is stateless (POST-only, no SSE/GET). Users must pass `--stateless` manually on every `thv run` invocation. Adding the field to the type system lets registries declare this property so it applies automatically.
- Adds `Stateless bool` to `BaseServerMetadata`, `ServerExtensions`, both legacy registry schema definitions (`server` and `remote_server`), and the publisher-provided schema. Updates bidirectional converters to preserve the field through round-trips.

Fixes #88

## Design notes

**Why `BaseServerMetadata` (shared) rather than `RemoteServerMetadata` only?** Stateless mode applies to both remote servers and container workloads — stacklok/toolhive#4515 explicitly supports both. Placing the field on `BaseServerMetadata` alongside `Transport` is consistent with how other transport-level properties are modeled. The trade-off is that `ImageMetadata` inherits a field that's irrelevant for stdio containers, but this mirrors existing fields like `TargetPort` and `ProxyPort` that only apply to HTTP transports.

**Interface addition.** `GetStateless()` is added to `ServerMetadata`, following the established pattern for all 14 existing `BaseServerMetadata` getters. Unlike `ProxyPort` (which predates the interface and is duplicated on both concrete types), `Stateless` follows the dominant pattern. No downstream repo implements `ServerMetadata` directly — all consumers use the concrete types, which inherit the getter through embedding.

## Test plan

- [x] Unit tests: converter round-trip for stateless=true on both remote and image servers
- [x] Unit tests: YAML/JSON marshal/unmarshal preserves the field
- [x] Unit tests: nil receiver returns false
- [x] Unit tests: `GetStateless()` through `ServerMetadata` interface
- [x] Existing "all fields" round-trip test updated to include stateless
- [x] `task lint-fix` — 0 issues
- [x] `task test` — all pass with race detection
- [x] `task license-check` — all headers present

Generated with [Claude Code](https://claude.com/claude-code)