### PR TITLE
Ship pre-bundled upstream-registry schema variant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,30 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Produce bundled upstream-registry schema
+        # Ships a bundled variant alongside the raw schema. The bundled
+        # version replaces the remote $refs to the MCP server schema
+        # with inline placeholder objects, letting JSON Schema viewers
+        # render the file without runtime ref resolution. Raw schema
+        # remains the canonical source.
+        run: |
+          mkdir -p build
+          jq '
+            (.. | objects | select(.["$ref"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json")) |=
+              {
+                type: "object",
+                description: "MCP server object — see MCP server schema: https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+              }
+          ' registry/types/data/upstream-registry.schema.json \
+            > build/upstream-registry.bundled.schema.json
+
+          # Sanity check: the MCP server URL should no longer appear as
+          # a $ref anywhere in the bundled output (only in descriptions).
+          if jq -e '[.. | objects | .["$ref"]? | select(. != null and (contains("static.modelcontextprotocol.io")))] | length > 0' build/upstream-registry.bundled.schema.json > /dev/null; then
+            echo "::error::Bundling failed: MCP server \$refs were not rewritten. The MCP server URL may have changed; update the jq filter above."
+            exit 1
+          fi
+
       - name: Upload schema artifacts to release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -25,6 +49,7 @@ jobs:
           gh release upload "${{ github.ref_name }}" \
             registry/types/data/skill.schema.json \
             registry/types/data/upstream-registry.schema.json \
+            build/upstream-registry.bundled.schema.json \
             registry/types/data/publisher-provided.schema.json \
             registry/types/data/toolhive-legacy-registry.schema.json \
             --clobber


### PR DESCRIPTION
## Summary

Adds `upstream-registry.bundled.schema.json` as a new release asset alongside the existing raw `upstream-registry.schema.json`. The bundled variant replaces the two remote `$ref`s that point at `https://static.modelcontextprotocol.io/schemas/.../server.schema.json` with inline placeholder objects, so consumers rendering the schema with a JSON-Schema viewer don't have to resolve them at runtime.

Raw schema stays as the canonical source — purely additive, no existing consumers affected.

## Motivation

[stacklok/docs-website](https://github.com/stacklok/docs-website) renders this schema using the Docusaurus JSON-Schema viewer plugin. That plugin can't resolve remote `$ref`s at render time, so docs-website runs a post-download bundling step via `@apidevtools/json-schema-ref-parser`. Shipping a pre-bundled variant lets the consumer just use it directly.

Part of the docs-website automation rollup in [PR #748](https://github.com/stacklok/docs-website/pull/748), alongside two related PRs on toolhive ([#4982 CRD tarball](https://github.com/stacklok/toolhive/pull/4982) + [#4983 re-exported core schemas](https://github.com/stacklok/toolhive/pull/4983)). Together these let docs-website stop running any transform scripts during release-doc regeneration.

## What's in this PR

- `.github/workflows/release.yml`: one new step that runs `jq` over `upstream-registry.schema.json` and writes a bundled variant to `build/upstream-registry.bundled.schema.json`. Uses jq (already on the runner) — no new dependencies, no new Node/tooling footprint in this Go library.
- The bundled file is added to the existing `gh release upload` call.

The jq filter only touches the two specific remote `$ref`s to the MCP server schema. Other `$ref`s (e.g., the skill schema self-reference) are left intact.

## Test plan

Local smoke test:

```bash
jq '
  (.. | objects | select(.["$ref"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json")) |=
    {
      type: "object",
      description: "MCP server object — see MCP server schema: https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
    }
' registry/types/data/upstream-registry.schema.json > /tmp/bundled.schema.json

# Confirm no MCP-server $refs remain:
jq '[.. | objects | .["$ref"]? | select(. != null and (contains("static.modelcontextprotocol.io")))] | length' /tmp/bundled.schema.json
# Should print: 0
```

Verified locally that:
- `.properties.data.properties.servers.items` transforms to `{type: object, description: "..."}`
- `.properties.data.properties.groups.items.properties.servers.items` transforms the same way
- The sanity check fails loudly if the MCP server URL ever changes and the filter doesn't match

## Notes

- If MCP bumps to a new schema version (`/2026-xx-xx/` in the URL), the sanity check fails with a clear "URL may have changed; update the jq filter" message. That's the intended feedback loop.
- This PR doesn't touch the raw schema's own $ref structure — it just produces a bundled SIBLING file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)