### PR TITLE
Fix goconst lint errors after golangci-lint v2.12 update

### DIFF
--- a/audit/event_test.go
+++ b/audit/event_test.go
@@ -15,16 +15,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	subjKeyUser      = "user"
+	subjKeyUserID    = "user_id"
+	subjKeyUserAgent = "user_agent"
+	targetKeyName    = "name"
+	targetKeyEndpt   = "endpoint"
+	targetKeyType    = "type"
+	targetTypeTool   = "tool"
+)
+
 func TestNewAuditEvent(t *testing.T) {
 	t.Parallel()
 	source := EventSource{
 		Type:  SourceTypeNetwork,
 		Value: "192.168.1.100",
-		Extra: map[string]any{"user_agent": "test-agent"},
+		Extra: map[string]any{subjKeyUserAgent: "test-agent"},
 	}
 	subjects := map[string]string{
-		"user":    "testuser",
-		"user_id": "user123",
+		subjKeyUser:   "testuser",
+		subjKeyUserID: "user123",
 	}
 
 	event := NewAuditEvent("test_event", source, OutcomeSuccess, subjects, "test-component")
@@ -42,7 +52,7 @@ func TestNewAuditEventWithID(t *testing.T) {
 	t.Parallel()
 	auditID := "custom-audit-id"
 	source := EventSource{Type: SourceTypeLocal, Value: "localhost"}
-	subjects := map[string]string{"user": "admin"}
+	subjects := map[string]string{subjKeyUser: "admin"}
 
 	event := NewAuditEventWithID(auditID, "admin_action", source, OutcomeSuccess, subjects, "admin-panel")
 
@@ -58,9 +68,9 @@ func TestAuditEventWithTarget(t *testing.T) {
 	t.Parallel()
 	event := NewAuditEvent("test", EventSource{}, OutcomeSuccess, map[string]string{}, "test")
 	target := map[string]string{
-		"type":     "tool",
-		"name":     "test-tool",
-		"endpoint": "/api/tools/test",
+		targetKeyType:  targetTypeTool,
+		targetKeyName:  "test-tool",
+		targetKeyEndpt: "/api/tools/test",
 	}
 
 	result := event.WithTarget(target)
@@ -106,21 +116,21 @@ func TestAuditEventJSONSerialization(t *testing.T) {
 		Type:  SourceTypeNetwork,
 		Value: "10.0.0.1",
 		Extra: map[string]any{
-			"user_agent": "Mozilla/5.0",
-			"request_id": "req-123",
+			subjKeyUserAgent: "Mozilla/5.0",
+			"request_id":     "req-123",
 		},
 	}
 	subjects := map[string]string{
-		"user":           "john.doe",
-		"user_id":        "user-456",
+		subjKeyUser:      "john.doe",
+		subjKeyUserID:    "user-456",
 		"client_name":    "test-client",
 		"client_version": "1.0.0",
 	}
 	target := map[string]string{
-		"type":     "tool",
-		"name":     "calculator",
-		"method":   "POST",
-		"endpoint": "/api/tools/calculator",
+		targetKeyType:  targetTypeTool,
+		targetKeyName:  "calculator",
+		"method":       "POST",
+		targetKeyEndpt: "/api/tools/calculator",
 	}
 
 	event := NewAuditEvent("mcp_tool_call", source, OutcomeSuccess, subjects, "calculator-service")
@@ -220,16 +230,16 @@ func TestAuditEventLogTo(t *testing.T) {
 	source := EventSource{
 		Type:  SourceTypeNetwork,
 		Value: "192.168.1.100",
-		Extra: map[string]any{"user_agent": "test-agent"},
+		Extra: map[string]any{subjKeyUserAgent: "test-agent"},
 	}
 	subjects := map[string]string{
-		"user":    "testuser",
-		"user_id": "user123",
+		subjKeyUser:   "testuser",
+		subjKeyUserID: "user123",
 	}
 	target := map[string]string{
-		"type":     "tool",
-		"name":     "calculator",
-		"endpoint": "/api/tools/calculator",
+		targetKeyType:  targetTypeTool,
+		targetKeyName:  "calculator",
+		targetKeyEndpt: "/api/tools/calculator",
 	}
 
 	event := NewAuditEvent("mcp_tool_call", source, OutcomeSuccess, subjects, "test-component")
@@ -262,12 +272,12 @@ func TestAuditEventLogTo(t *testing.T) {
 
 	subjectsData, ok := logEntry["subjects"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "testuser", subjectsData["user"])
-	assert.Equal(t, "user123", subjectsData["user_id"])
+	assert.Equal(t, "testuser", subjectsData[subjKeyUser])
+	assert.Equal(t, "user123", subjectsData[subjKeyUserID])
 
 	targetData, ok := logEntry["target"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "tool", targetData["type"])
-	assert.Equal(t, "calculator", targetData["name"])
-	assert.Equal(t, "/api/tools/calculator", targetData["endpoint"])
+	assert.Equal(t, targetTypeTool, targetData[targetKeyType])
+	assert.Equal(t, "calculator", targetData[targetKeyName])
+	assert.Equal(t, "/api/tools/calculator", targetData[targetKeyEndpt])
 }

--- a/cel/engine_test.go
+++ b/cel/engine_test.go
@@ -14,11 +14,28 @@ import (
 	"github.com/stacklok/toolhive-core/cel"
 )
 
+const (
+	claimsVar    = "claims"
+	claimSub     = "sub"
+	claimAct     = "act"
+	claimGroups  = "groups"
+	groupAdmins  = "admins"
+	groupUsers   = "users"
+	userAgent456 = "agent456"
+	testUser123  = "user123"
+
+	testExprSubUser123         = `claims["sub"] == "user123"`
+	testExprAdminsInGroups     = `"admins" in claims["groups"]`
+	testExprActInClaims        = `"act" in claims`
+	testExprAdminsNotDelegated = `"admins" in claims["groups"] && !("act" in claims)`
+	testExprTernaryDelegated   = `"act" in claims ? "delegated" : "direct"`
+)
+
 // newTestClaimsEngine creates a CEL engine for testing claims-based expressions.
 // This demonstrates how consumers should configure the generic CEL engine.
 func newTestClaimsEngine() *cel.Engine {
 	return cel.NewEngine(
-		celgo.Variable("claims", celgo.MapType(celgo.StringType, celgo.DynType)),
+		celgo.Variable(claimsVar, celgo.MapType(celgo.StringType, celgo.DynType)),
 	)
 }
 
@@ -29,7 +46,7 @@ func TestNewEngine(t *testing.T) {
 	require.NotNil(t, engine)
 
 	// Should be able to compile a valid expression
-	expr, err := engine.Compile(`claims["sub"] == "user123"`)
+	expr, err := engine.Compile(testExprSubUser123)
 	require.NoError(t, err)
 	require.NotNil(t, expr)
 }
@@ -45,15 +62,15 @@ func TestEngine_Compile_ValidExpressions(t *testing.T) {
 	}{
 		{
 			name: "string equality",
-			expr: `claims["sub"] == "user123"`,
+			expr: testExprSubUser123,
 		},
 		{
 			name: "membership in array",
-			expr: `"admins" in claims["groups"]`,
+			expr: testExprAdminsInGroups,
 		},
 		{
 			name: "key exists in map",
-			expr: `"act" in claims`,
+			expr: testExprActInClaims,
 		},
 		{
 			name: "nested access",
@@ -61,7 +78,7 @@ func TestEngine_Compile_ValidExpressions(t *testing.T) {
 		},
 		{
 			name: "boolean and",
-			expr: `"admins" in claims["groups"] && !("act" in claims)`,
+			expr: testExprAdminsNotDelegated,
 		},
 		{
 			name: "boolean or",
@@ -77,7 +94,7 @@ func TestEngine_Compile_ValidExpressions(t *testing.T) {
 		},
 		{
 			name: "ternary expression",
-			expr: `"act" in claims ? "delegated" : "direct"`,
+			expr: testExprTernaryDelegated,
 		},
 		{
 			name: "true literal",
@@ -179,7 +196,7 @@ func TestEngine_Check(t *testing.T) {
 
 	t.Run("valid expression", func(t *testing.T) {
 		t.Parallel()
-		err := engine.Check(`claims["sub"] == "user123"`)
+		err := engine.Check(testExprSubUser123)
 		require.NoError(t, err)
 	})
 
@@ -206,92 +223,92 @@ func TestCompiledExpression_Evaluate(t *testing.T) {
 	}{
 		{
 			name: "string equality true",
-			expr: `claims["sub"] == "user123"`,
+			expr: testExprSubUser123,
 			claims: map[string]any{
-				"sub": "user123",
+				claimSub: testUser123,
 			},
 			expected: true,
 		},
 		{
 			name: "string equality false",
-			expr: `claims["sub"] == "user123"`,
+			expr: testExprSubUser123,
 			claims: map[string]any{
-				"sub": "other-user",
+				claimSub: "other-user",
 			},
 			expected: false,
 		},
 		{
 			name: "membership in array true",
-			expr: `"admins" in claims["groups"]`,
+			expr: testExprAdminsInGroups,
 			claims: map[string]any{
-				"groups": []any{"users", "admins", "developers"},
+				claimGroups: []any{groupUsers, groupAdmins, "developers"},
 			},
 			expected: true,
 		},
 		{
 			name: "membership in array false",
-			expr: `"admins" in claims["groups"]`,
+			expr: testExprAdminsInGroups,
 			claims: map[string]any{
-				"groups": []any{"users", "developers"},
+				claimGroups: []any{groupUsers, "developers"},
 			},
 			expected: false,
 		},
 		{
 			name: "key exists in map true",
-			expr: `"act" in claims`,
+			expr: testExprActInClaims,
 			claims: map[string]any{
-				"sub": "user123",
-				"act": map[string]any{
-					"sub": "agent456",
+				claimSub: testUser123,
+				claimAct: map[string]any{
+					claimSub: userAgent456,
 				},
 			},
 			expected: true,
 		},
 		{
 			name: "key missing from map",
-			expr: `"act" in claims`,
+			expr: testExprActInClaims,
 			claims: map[string]any{
-				"sub": "user123",
+				claimSub: testUser123,
 			},
 			expected: false,
 		},
 		{
 			name: "complex boolean expression",
-			expr: `"admins" in claims["groups"] && !("act" in claims)`,
+			expr: testExprAdminsNotDelegated,
 			claims: map[string]any{
-				"sub":    "user123",
-				"groups": []any{"admins"},
+				claimSub:    testUser123,
+				claimGroups: []any{groupAdmins},
 			},
 			expected: true,
 		},
 		{
 			name: "complex boolean with agent delegation",
-			expr: `"admins" in claims["groups"] && !("act" in claims)`,
+			expr: testExprAdminsNotDelegated,
 			claims: map[string]any{
-				"sub":    "user123",
-				"groups": []any{"admins"},
-				"act": map[string]any{
-					"sub": "agent456",
+				claimSub:    testUser123,
+				claimGroups: []any{groupAdmins},
+				claimAct: map[string]any{
+					claimSub: userAgent456,
 				},
 			},
 			expected: false,
 		},
 		{
 			name: "ternary expression",
-			expr: `"act" in claims ? "delegated" : "direct"`,
+			expr: testExprTernaryDelegated,
 			claims: map[string]any{
-				"sub": "user123",
-				"act": map[string]any{
-					"sub": "agent456",
+				claimSub: testUser123,
+				claimAct: map[string]any{
+					claimSub: userAgent456,
 				},
 			},
 			expected: "delegated",
 		},
 		{
 			name: "ternary expression no delegation",
-			expr: `"act" in claims ? "delegated" : "direct"`,
+			expr: testExprTernaryDelegated,
 			claims: map[string]any{
-				"sub": "user123",
+				claimSub: testUser123,
 			},
 			expected: "direct",
 		},
@@ -316,7 +333,7 @@ func TestCompiledExpression_Evaluate(t *testing.T) {
 			expr, err := engine.Compile(tt.expr)
 			require.NoError(t, err)
 
-			ctx := map[string]any{"claims": tt.claims}
+			ctx := map[string]any{claimsVar: tt.claims}
 			result, err := expr.Evaluate(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
@@ -332,10 +349,10 @@ func TestCompiledExpression_EvaluateBool(t *testing.T) {
 	t.Run("returns true", func(t *testing.T) {
 		t.Parallel()
 
-		expr, err := engine.Compile(`claims["sub"] == "user123"`)
+		expr, err := engine.Compile(testExprSubUser123)
 		require.NoError(t, err)
 
-		ctx := map[string]any{"claims": map[string]any{"sub": "user123"}}
+		ctx := map[string]any{claimsVar: map[string]any{claimSub: testUser123}}
 		result, err := expr.EvaluateBool(ctx)
 		require.NoError(t, err)
 		assert.True(t, result)
@@ -344,10 +361,10 @@ func TestCompiledExpression_EvaluateBool(t *testing.T) {
 	t.Run("returns false", func(t *testing.T) {
 		t.Parallel()
 
-		expr, err := engine.Compile(`claims["sub"] == "user123"`)
+		expr, err := engine.Compile(testExprSubUser123)
 		require.NoError(t, err)
 
-		ctx := map[string]any{"claims": map[string]any{"sub": "other"}}
+		ctx := map[string]any{claimsVar: map[string]any{claimSub: "other"}}
 		result, err := expr.EvaluateBool(ctx)
 		require.NoError(t, err)
 		assert.False(t, result)
@@ -359,7 +376,7 @@ func TestCompiledExpression_EvaluateBool(t *testing.T) {
 		expr, err := engine.Compile(`claims["sub"]`)
 		require.NoError(t, err)
 
-		ctx := map[string]any{"claims": map[string]any{"sub": "user123"}}
+		ctx := map[string]any{claimsVar: map[string]any{claimSub: testUser123}}
 		_, err = expr.EvaluateBool(ctx)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, cel.ErrInvalidResult)
@@ -373,7 +390,7 @@ func TestCompiledExpression_EvaluateBool(t *testing.T) {
 		require.NoError(t, err)
 
 		// Provide an empty claims map so the nested access fails at runtime
-		ctx := map[string]any{"claims": map[string]any{}}
+		ctx := map[string]any{claimsVar: map[string]any{}}
 		_, err = expr.EvaluateBool(ctx)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, cel.ErrEvaluation)
@@ -422,7 +439,7 @@ func TestEngine_WithMaxExpressionLength(t *testing.T) {
 
 		engine := newTestClaimsEngine().WithMaxExpressionLength(10)
 
-		_, err := engine.Compile(`claims["sub"] == "user123"`)
+		_, err := engine.Compile(testExprSubUser123)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, cel.ErrExpressionCheck)
 	})
@@ -442,7 +459,7 @@ func TestEngine_WithMaxExpressionLength(t *testing.T) {
 
 		engine := newTestClaimsEngine().WithMaxExpressionLength(5)
 
-		err := engine.Check(`claims["sub"] == "user123"`)
+		err := engine.Check(testExprSubUser123)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, cel.ErrExpressionCheck)
 	})
@@ -463,10 +480,10 @@ func TestEngine_WithCostLimit(t *testing.T) {
 
 		engine := newTestClaimsEngine().WithCostLimit(cel.DefaultCostLimit)
 
-		expr, err := engine.Compile(`claims["sub"] == "user123"`)
+		expr, err := engine.Compile(testExprSubUser123)
 		require.NoError(t, err)
 
-		ctx := map[string]any{"claims": map[string]any{"sub": "user123"}}
+		ctx := map[string]any{claimsVar: map[string]any{claimSub: testUser123}}
 		result, err := expr.EvaluateBool(ctx)
 		require.NoError(t, err)
 		assert.True(t, result)
@@ -477,10 +494,10 @@ func TestEngine_WithCostLimit(t *testing.T) {
 
 		engine := newTestClaimsEngine().WithCostLimit(0)
 
-		expr, err := engine.Compile(`claims["sub"] == "user123"`)
+		expr, err := engine.Compile(testExprSubUser123)
 		require.NoError(t, err)
 
-		ctx := map[string]any{"claims": map[string]any{"sub": "user123"}}
+		ctx := map[string]any{claimsVar: map[string]any{claimSub: testUser123}}
 		_, err = expr.EvaluateBool(ctx)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, cel.ErrEvaluation)
@@ -493,7 +510,7 @@ func TestEngine_Concurrency(t *testing.T) {
 	engine := newTestClaimsEngine()
 
 	// Compile the expression once
-	expr, err := engine.Compile(`"admins" in claims["groups"]`)
+	expr, err := engine.Compile(testExprAdminsInGroups)
 	require.NoError(t, err)
 
 	// Evaluate concurrently
@@ -503,14 +520,14 @@ func TestEngine_Concurrency(t *testing.T) {
 
 	for i := 0; i < numGoroutines; i++ {
 		go func(i int) {
-			groups := []any{"users"}
+			groups := []any{groupUsers}
 			if i%2 == 0 {
-				groups = append(groups, "admins")
+				groups = append(groups, groupAdmins)
 			}
 
 			ctx := map[string]any{
-				"claims": map[string]any{
-					"groups": groups,
+				claimsVar: map[string]any{
+					claimGroups: groups,
 				},
 			}
 

--- a/container/verifier/attestations.go
+++ b/container/verifier/attestations.go
@@ -68,7 +68,7 @@ func bundleFromAttestation(imageRef string, keychain authn.Keychain) ([]sigstore
 		// where the referrers fallback tag doesn't propagate the inner manifest's
 		// artifactType.
 		if !hasSigstoreBundlePrefix(refDesc.ArtifactType) &&
-			refDesc.ArtifactType != "application/vnd.oci.empty.v1+json" &&
+			refDesc.ArtifactType != MediaTypeOCIEmptyV1JSON &&
 			refDesc.ArtifactType != "" {
 			continue
 		}

--- a/container/verifier/attestations_test.go
+++ b/container/verifier/attestations_test.go
@@ -49,7 +49,7 @@ func TestHasSigstoreBundlePrefix(t *testing.T) {
 		},
 		{
 			name:  "v0.3 bundle type",
-			input: "application/vnd.dev.sigstore.bundle.v0.3+json",
+			input: MediaTypeSigstoreBundleV03JSON,
 			want:  true,
 		},
 		{
@@ -59,12 +59,12 @@ func TestHasSigstoreBundlePrefix(t *testing.T) {
 		},
 		{
 			name:  "OCI empty type (ambiguous, not a bundle)",
-			input: "application/vnd.oci.empty.v1+json",
+			input: MediaTypeOCIEmptyV1JSON,
 			want:  false,
 		},
 		{
 			name:  "cosign simplesigning type",
-			input: "application/vnd.dev.cosign.simplesigning.v1+json",
+			input: MediaTypeCosignSimpleSigningV1JSON,
 			want:  false,
 		},
 		{
@@ -105,7 +105,7 @@ func TestIsSigstoreBundle(t *testing.T) {
 			name: "config artifactType is sigstore bundle v0.3",
 			img: &fakeImage{manifest: &v1.Manifest{
 				Config: v1.Descriptor{
-					ArtifactType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+					ArtifactType: MediaTypeSigstoreBundleV03JSON,
 				},
 			}},
 			want: true,
@@ -123,10 +123,10 @@ func TestIsSigstoreBundle(t *testing.T) {
 			name: "layer media type is sigstore bundle",
 			img: &fakeImage{manifest: &v1.Manifest{
 				Config: v1.Descriptor{
-					ArtifactType: "application/vnd.oci.empty.v1+json",
+					ArtifactType: MediaTypeOCIEmptyV1JSON,
 				},
 				Layers: []v1.Descriptor{
-					{MediaType: types.MediaType("application/vnd.dev.sigstore.bundle.v0.3+json")},
+					{MediaType: types.MediaType(MediaTypeSigstoreBundleV03JSON)},
 				},
 			}},
 			want: true,
@@ -135,7 +135,7 @@ func TestIsSigstoreBundle(t *testing.T) {
 			name: "neither config nor layers match",
 			img: &fakeImage{manifest: &v1.Manifest{
 				Config: v1.Descriptor{
-					ArtifactType: "application/vnd.oci.empty.v1+json",
+					ArtifactType: MediaTypeOCIEmptyV1JSON,
 				},
 				Layers: []v1.Descriptor{
 					{MediaType: types.MediaType("application/vnd.oci.image.layer.v1.tar+gzip")},
@@ -158,7 +158,7 @@ func TestIsSigstoreBundle(t *testing.T) {
 			img: &fakeImage{manifest: &v1.Manifest{
 				Layers: []v1.Descriptor{
 					{MediaType: types.MediaType("application/octet-stream")},
-					{MediaType: types.MediaType("application/vnd.dev.sigstore.bundle.v0.3+json")},
+					{MediaType: types.MediaType(MediaTypeSigstoreBundleV03JSON)},
 				},
 			}},
 			want: true,
@@ -167,7 +167,7 @@ func TestIsSigstoreBundle(t *testing.T) {
 			name: "cosign simplesigning layer is not a sigstore bundle",
 			img: &fakeImage{manifest: &v1.Manifest{
 				Layers: []v1.Descriptor{
-					{MediaType: types.MediaType("application/vnd.dev.cosign.simplesigning.v1+json")},
+					{MediaType: types.MediaType(MediaTypeCosignSimpleSigningV1JSON)},
 				},
 			}},
 			want: false,
@@ -203,13 +203,13 @@ func TestBundleFromAttestation_FilterPredicates(t *testing.T) {
 	}{
 		{
 			name:     "sigstore bundle v0.3 - accepted without deep inspect",
-			artType:  "application/vnd.dev.sigstore.bundle.v0.3+json",
+			artType:  MediaTypeSigstoreBundleV03JSON,
 			wantSkip: false,
 			wantDeep: false,
 		},
 		{
 			name:     "OCI empty (go-containerregistry bug) - needs deep inspect",
-			artType:  "application/vnd.oci.empty.v1+json",
+			artType:  MediaTypeOCIEmptyV1JSON,
 			wantSkip: false,
 			wantDeep: true,
 		},
@@ -221,7 +221,7 @@ func TestBundleFromAttestation_FilterPredicates(t *testing.T) {
 		},
 		{
 			name:     "cosign simplesigning - fast-path skip",
-			artType:  "application/vnd.dev.cosign.simplesigning.v1+json",
+			artType:  MediaTypeCosignSimpleSigningV1JSON,
 			wantSkip: true,
 			wantDeep: false, // never reached
 		},
@@ -239,7 +239,7 @@ func TestBundleFromAttestation_FilterPredicates(t *testing.T) {
 
 			// Replicate the skip condition from bundleFromAttestation
 			skip := !hasSigstoreBundlePrefix(tt.artType) &&
-				tt.artType != "application/vnd.oci.empty.v1+json" &&
+				tt.artType != MediaTypeOCIEmptyV1JSON &&
 				tt.artType != ""
 			require.Equal(t, tt.wantSkip, skip, "skip predicate mismatch")
 

--- a/container/verifier/sigstore.go
+++ b/container/verifier/sigstore.go
@@ -150,7 +150,7 @@ func getSimpleSigningLayersFromSignatureManifest(manifestRef string, keychain au
 	// Loop through its layers and extract the simple signing layers
 	var results []v1.Descriptor
 	for _, layer := range manifest.Layers {
-		if layer.MediaType == "application/vnd.dev.cosign.simplesigning.v1+json" {
+		if layer.MediaType == MediaTypeCosignSimpleSigningV1JSON {
 			// We found a simple signing layer, store and return it even if we may fail to parse it later
 			results = append(results, layer)
 		}

--- a/container/verifier/utils.go
+++ b/container/verifier/utils.go
@@ -37,6 +37,13 @@ var (
 	MaxAttestationsBytesLimit int64 = 10 * 1024 * 1024
 )
 
+// OCI and Sigstore media type constants used when inspecting referrer manifests.
+const (
+	MediaTypeOCIEmptyV1JSON            = "application/vnd.oci.empty.v1+json"
+	MediaTypeCosignSimpleSigningV1JSON = "application/vnd.dev.cosign.simplesigning.v1+json"
+	MediaTypeSigstoreBundleV03JSON     = "application/vnd.dev.sigstore.bundle.v0.3+json"
+)
+
 const (
 	sigstoreBundleMediaType01 = "application/vnd.dev.sigstore.bundle+json;version=0.1"
 	// githubTokenIssuer is the issuer stamped into sigstore certs

--- a/oci/skills/gzip_test.go
+++ b/oci/skills/gzip_test.go
@@ -149,8 +149,8 @@ func TestCompressTar_Reproducible(t *testing.T) {
 	t.Parallel()
 
 	files := []FileEntry{
-		{Path: "b.txt", Content: []byte("content b")},
-		{Path: "a.txt", Content: []byte("content a")},
+		{Path: testFileB, Content: []byte("content b")},
+		{Path: testFileA, Content: []byte("content a")},
 	}
 
 	tarOpts := DefaultTarOptions()
@@ -169,8 +169,8 @@ func TestCompressTar_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	originalFiles := []FileEntry{
-		{Path: "a.txt", Content: []byte("content a")},
-		{Path: "dir/b.txt", Content: []byte("content b")},
+		{Path: testFileA, Content: []byte("content a")},
+		{Path: "dir/" + testFileB, Content: []byte("content b")},
 	}
 
 	tarOpts := DefaultTarOptions()

--- a/oci/skills/mediatypes.go
+++ b/oci/skills/mediatypes.go
@@ -134,11 +134,21 @@ func ParsePlatform(s string) (ocispec.Platform, error) {
 	return p, nil
 }
 
+// OS and architecture constants for OCI platform specifications.
+const (
+	// OSLinux is the Linux OS identifier used in OCI platform specs.
+	OSLinux = "linux"
+	// ArchAMD64 is the x86-64 architecture identifier used in OCI platform specs.
+	ArchAMD64 = "amd64"
+	// ArchARM64 is the 64-bit ARM architecture identifier used in OCI platform specs.
+	ArchARM64 = "arm64"
+)
+
 // DefaultPlatforms are the default platforms for skill artifacts.
 // These cover most Kubernetes clusters.
 var DefaultPlatforms = []ocispec.Platform{
-	{OS: "linux", Architecture: "amd64"},
-	{OS: "linux", Architecture: "arm64"},
+	{OS: OSLinux, Architecture: ArchAMD64},
+	{OS: OSLinux, Architecture: ArchARM64},
 }
 
 // ParseRequiresAnnotation parses skill dependency references from manifest annotations.

--- a/oci/skills/mediatypes_test.go
+++ b/oci/skills/mediatypes_test.go
@@ -27,7 +27,7 @@ func TestSkillConfigFromImageConfig(t *testing.T) {
 			config: &ocispec.Image{
 				Config: ocispec.ImageConfig{
 					Labels: map[string]string{
-						LabelSkillName:         "my-skill",
+						LabelSkillName:         testSkillMySkill,
 						LabelSkillDescription:  "A test skill",
 						LabelSkillVersion:      "1.0.0",
 						LabelSkillLicense:      "Apache-2.0",
@@ -36,7 +36,7 @@ func TestSkillConfigFromImageConfig(t *testing.T) {
 					},
 				},
 			},
-			wantName:  "my-skill",
+			wantName:  testSkillMySkill,
 			wantTools: []string{"tool1", "tool2"},
 			wantFiles: []string{"file1.txt", "file2.txt"},
 		},
@@ -80,7 +80,7 @@ func TestSkillConfigFromImageConfig(t *testing.T) {
 				Config: ocispec.ImageConfig{
 					Labels: map[string]string{
 						LabelSkillName:         "bad-tools",
-						LabelSkillAllowedTools: "not-json",
+						LabelSkillAllowedTools: testNotJSON,
 					},
 				},
 			},
@@ -92,7 +92,7 @@ func TestSkillConfigFromImageConfig(t *testing.T) {
 				Config: ocispec.ImageConfig{
 					Labels: map[string]string{
 						LabelSkillName:  "bad-files",
-						LabelSkillFiles: "not-json",
+						LabelSkillFiles: testNotJSON,
 					},
 				},
 			},
@@ -131,19 +131,19 @@ func TestParsePlatform(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:  "linux/amd64",
-			input: "linux/amd64",
-			want:  ocispec.Platform{OS: "linux", Architecture: "amd64"},
+			name:  testPlatformAMD64,
+			input: testPlatformAMD64,
+			want:  ocispec.Platform{OS: OSLinux, Architecture: ArchAMD64},
 		},
 		{
 			name:  "linux/arm64",
 			input: "linux/arm64",
-			want:  ocispec.Platform{OS: "linux", Architecture: "arm64"},
+			want:  ocispec.Platform{OS: OSLinux, Architecture: ArchARM64},
 		},
 		{
-			name:  "linux/arm/v7",
-			input: "linux/arm/v7",
-			want:  ocispec.Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
+			name:  testPlatformARMv7,
+			input: testPlatformARMv7,
+			want:  ocispec.Platform{OS: OSLinux, Architecture: testArchARM, Variant: "v7"},
 		},
 		{
 			name:    "no slash",
@@ -197,13 +197,13 @@ func TestPlatformString(t *testing.T) {
 	}{
 		{
 			name:     "os/arch",
-			platform: ocispec.Platform{OS: "linux", Architecture: "amd64"},
-			want:     "linux/amd64",
+			platform: ocispec.Platform{OS: OSLinux, Architecture: ArchAMD64},
+			want:     testPlatformAMD64,
 		},
 		{
 			name:     "os/arch/variant",
-			platform: ocispec.Platform{OS: "linux", Architecture: "arm", Variant: "v7"},
-			want:     "linux/arm/v7",
+			platform: ocispec.Platform{OS: OSLinux, Architecture: testArchARM, Variant: "v7"},
+			want:     testPlatformARMv7,
 		},
 	}
 
@@ -219,9 +219,9 @@ func TestParsePlatform_PlatformString_Roundtrip(t *testing.T) {
 	t.Parallel()
 
 	platforms := []ocispec.Platform{
-		{OS: "linux", Architecture: "amd64"},
-		{OS: "linux", Architecture: "arm64"},
-		{OS: "linux", Architecture: "arm", Variant: "v7"},
+		{OS: OSLinux, Architecture: ArchAMD64},
+		{OS: OSLinux, Architecture: ArchARM64},
+		{OS: OSLinux, Architecture: testArchARM, Variant: "v7"},
 	}
 
 	for _, p := range platforms {
@@ -261,7 +261,7 @@ func TestParseRequiresAnnotation(t *testing.T) {
 		{
 			name: "invalid JSON",
 			annotations: map[string]string{
-				AnnotationSkillRequires: "not-json",
+				AnnotationSkillRequires: testNotJSON,
 			},
 			want: nil,
 		},
@@ -286,6 +286,6 @@ func TestDefaultPlatforms(t *testing.T) {
 	t.Parallel()
 
 	require.Len(t, DefaultPlatforms, 2)
-	assert.Equal(t, ocispec.Platform{OS: "linux", Architecture: "amd64"}, DefaultPlatforms[0])
-	assert.Equal(t, ocispec.Platform{OS: "linux", Architecture: "arm64"}, DefaultPlatforms[1])
+	assert.Equal(t, ocispec.Platform{OS: OSLinux, Architecture: ArchAMD64}, DefaultPlatforms[0])
+	assert.Equal(t, ocispec.Platform{OS: OSLinux, Architecture: ArchARM64}, DefaultPlatforms[1])
 }

--- a/oci/skills/packager.go
+++ b/oci/skills/packager.go
@@ -93,6 +93,9 @@ type skillDirContent struct {
 	fm *frontmatter
 }
 
+// SkillFileName is the required metadata file name for a skill directory.
+const SkillFileName = "SKILL.md"
+
 // maxFrontmatterSize limits frontmatter to prevent YAML parsing attacks.
 const maxFrontmatterSize = 64 * 1024
 
@@ -223,7 +226,7 @@ func readSkillDirectory(dir string) (*skillDirContent, error) {
 	}
 
 	// Read SKILL.md (required)
-	skillMDPath := filepath.Join(dir, "SKILL.md")
+	skillMDPath := filepath.Join(dir, SkillFileName)
 	skillMD, err := os.ReadFile(skillMDPath) //#nosec G304 -- path constructed from user-provided skill directory
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -317,7 +320,7 @@ func collectSkillFiles(dir string) (map[string][]byte, error) {
 		}
 
 		// Skip SKILL.md since we handle it separately
-		if relPath == "SKILL.md" {
+		if relPath == SkillFileName {
 			return nil
 		}
 
@@ -397,7 +400,7 @@ func createContentLayer(content *skillDirContent, opts PackageOptions) (compress
 
 	// Add SKILL.md first
 	files = append(files, FileEntry{
-		Path:    "SKILL.md",
+		Path:    SkillFileName,
 		Content: content.skillMD,
 	})
 
@@ -439,7 +442,7 @@ func createOCIConfig(
 	opts PackageOptions,
 ) (*ocispec.Image, *SkillConfig) {
 	// Collect all file paths
-	allFiles := []string{"SKILL.md"}
+	allFiles := []string{SkillFileName}
 	for p := range content.files {
 		allFiles = append(allFiles, p)
 	}

--- a/oci/skills/packager_test.go
+++ b/oci/skills/packager_test.go
@@ -122,7 +122,7 @@ func TestPackager_Package_VerifyLayer(t *testing.T) {
 
 	found := false
 	for _, f := range files {
-		if f.Path == "SKILL.md" {
+		if f.Path == SkillFileName {
 			found = true
 			break
 		}
@@ -182,8 +182,8 @@ func TestPackager_Package_VerifyOCIConfig(t *testing.T) {
 	var ociConfig ocispec.Image
 	require.NoError(t, json.Unmarshal(configBytes, &ociConfig))
 
-	assert.Equal(t, "amd64", ociConfig.Architecture)
-	assert.Equal(t, "linux", ociConfig.OS)
+	assert.Equal(t, ArchAMD64, ociConfig.Architecture)
+	assert.Equal(t, OSLinux, ociConfig.OS)
 	assert.NotNil(t, ociConfig.Created, "top-level created field should be set")
 	assert.Equal(t, "layers", ociConfig.RootFS.Type)
 	require.Len(t, ociConfig.RootFS.DiffIDs, 1)
@@ -197,7 +197,7 @@ func TestPackager_Package_VerifyOCIConfig(t *testing.T) {
 
 	var allowedTools []string
 	require.NoError(t, json.Unmarshal([]byte(labels[LabelSkillAllowedTools]), &allowedTools))
-	assert.Equal(t, []string{"Read", "Grep"}, allowedTools)
+	assert.Equal(t, []string{testToolRead, testToolGrep}, allowedTools)
 
 	require.Len(t, ociConfig.History, 1)
 	assert.Equal(t, "toolhive package", ociConfig.History[0].CreatedBy)
@@ -212,8 +212,8 @@ func TestPackager_Package_MultiPlatformConfigMatch(t *testing.T) {
 
 	packager := NewPackager(store)
 	platforms := []ocispec.Platform{
-		{OS: "linux", Architecture: "amd64"},
-		{OS: "linux", Architecture: "arm64"},
+		{OS: OSLinux, Architecture: ArchAMD64},
+		{OS: OSLinux, Architecture: ArchARM64},
 	}
 	opts := PackageOptions{
 		Epoch:     time.Unix(0, 0).UTC(),
@@ -299,7 +299,7 @@ version: 1.0.0
 ---
 # No Name Skill
 `
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, SkillFileName), []byte(skillMD), 0600))
 
 	store, err := NewStore(t.TempDir())
 	require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestPackager_Package_InvalidFrontmatter(t *testing.T) {
 			t.Parallel()
 
 			dir := t.TempDir()
-			require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(tt.content), 0600))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, SkillFileName), []byte(tt.content), 0600))
 
 			store, err := NewStore(t.TempDir())
 			require.NoError(t, err)
@@ -475,10 +475,10 @@ license: MIT
 ---
 # Body`,
 			want: &frontmatter{
-				Name:         "my-skill",
+				Name:         testSkillMySkill,
 				Description:  "A great skill",
 				Version:      "2.0.0",
-				AllowedTools: stringOrSlice{"Read", "Write"},
+				AllowedTools: stringOrSlice{testToolRead, "Write"},
 				License:      "MIT",
 			},
 		},
@@ -491,9 +491,9 @@ allowed-tools: Read Grep Glob
 ---
 # Body`,
 			want: &frontmatter{
-				Name:         "my-skill",
+				Name:         testSkillMySkill,
 				Description:  "A skill",
-				AllowedTools: stringOrSlice{"Read", "Grep", "Glob"},
+				AllowedTools: stringOrSlice{testToolRead, testToolGrep, "Glob"},
 			},
 		},
 		{
@@ -505,9 +505,9 @@ allowed-tools: Read, Grep, Glob
 ---
 # Body`,
 			want: &frontmatter{
-				Name:         "my-skill",
+				Name:         testSkillMySkill,
 				Description:  "A skill",
-				AllowedTools: stringOrSlice{"Read", "Grep", "Glob"},
+				AllowedTools: stringOrSlice{testToolRead, testToolGrep, "Glob"},
 			},
 		},
 		{
@@ -547,7 +547,7 @@ version: 1.0.0
 ---
 # Too Many Files Skill
 `
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, SkillFileName), []byte(skillMD), 0600))
 
 	// Create maxSkillFiles + 1 extra files (SKILL.md is excluded from the count)
 	for i := range maxSkillFiles + 1 {
@@ -608,7 +608,7 @@ func TestPackager_Package_SentinelErrors(t *testing.T) {
 				t.Helper()
 				dir := t.TempDir()
 				require.NoError(t, os.WriteFile(
-					filepath.Join(dir, "SKILL.md"),
+					filepath.Join(dir, SkillFileName),
 					[]byte("# no frontmatter\n"),
 					0600,
 				))
@@ -622,7 +622,7 @@ func TestPackager_Package_SentinelErrors(t *testing.T) {
 				t.Helper()
 				dir := t.TempDir()
 				require.NoError(t, os.WriteFile(
-					filepath.Join(dir, "SKILL.md"),
+					filepath.Join(dir, SkillFileName),
 					[]byte("---\nname: test\n# never closed"),
 					0600,
 				))
@@ -639,7 +639,7 @@ func TestPackager_Package_SentinelErrors(t *testing.T) {
 				buf.WriteString("---\nname: test\nfiller: ")
 				buf.Write(bytes.Repeat([]byte("a"), maxFrontmatterSize+1))
 				buf.WriteString("\n---\n# body\n")
-				require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), buf.Bytes(), 0600))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, SkillFileName), buf.Bytes(), 0600))
 				return dir
 			},
 			wantErr: ErrInvalidFrontmatter,
@@ -650,7 +650,7 @@ func TestPackager_Package_SentinelErrors(t *testing.T) {
 				t.Helper()
 				dir := t.TempDir()
 				require.NoError(t, os.WriteFile(
-					filepath.Join(dir, "SKILL.md"),
+					filepath.Join(dir, SkillFileName),
 					[]byte("---\nname: [unclosed\n---\n# body\n"),
 					0600,
 				))
@@ -664,7 +664,7 @@ func TestPackager_Package_SentinelErrors(t *testing.T) {
 				t.Helper()
 				dir := t.TempDir()
 				require.NoError(t, os.WriteFile(
-					filepath.Join(dir, "SKILL.md"),
+					filepath.Join(dir, SkillFileName),
 					[]byte("---\ndescription: nameless skill\n---\n# body\n"),
 					0600,
 				))
@@ -760,7 +760,7 @@ allowed-tools:
 
 This is a test skill.
 `
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, SkillFileName), []byte(skillMD), 0600))
 
 	return dir
 }
@@ -775,7 +775,7 @@ version: 1.0.0
 ---
 # Test Skill
 `
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMD), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, SkillFileName), []byte(skillMD), 0600))
 }
 
 func createTestSkillDirWithScripts(t *testing.T) string {

--- a/oci/skills/registry_test.go
+++ b/oci/skills/registry_test.go
@@ -78,7 +78,7 @@ func TestIsManifestMediaType(t *testing.T) {
 		{"Docker manifest list", "application/vnd.docker.distribution.manifest.list.v2+json", true},
 		{"OCI config", "application/vnd.oci.image.config.v1+json", false},
 		{"OCI layer", "application/vnd.oci.image.layer.v1.tar+gzip", false},
-		{"octet-stream", "application/octet-stream", false},
+		{"octet-stream", mediaTypeOctetStream, false},
 	}
 
 	for _, tt := range tests {
@@ -316,7 +316,7 @@ func TestPushPull_IndexRoundTrip(t *testing.T) {
 				MediaType: ocispec.MediaTypeImageManifest,
 				Digest:    manifestDigest,
 				Size:      int64(len(manifestBytes)),
-				Platform:  &ocispec.Platform{OS: "linux", Architecture: "amd64"},
+				Platform:  &ocispec.Platform{OS: OSLinux, Architecture: ArchAMD64},
 			},
 		},
 	}

--- a/oci/skills/store.go
+++ b/oci/skills/store.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stacklok/toolhive-core/httperr"
 )
 
+const mediaTypeOctetStream = "application/octet-stream"
+
 // Store provides local OCI artifact storage backed by an OCI Image Layout.
 type Store struct {
 	root  string
@@ -56,7 +58,7 @@ func DefaultStoreRoot() string {
 func (s *Store) PutBlob(ctx context.Context, content []byte) (digest.Digest, error) {
 	d := digest.FromBytes(content)
 	desc := ocispec.Descriptor{
-		MediaType: "application/octet-stream",
+		MediaType: mediaTypeOctetStream,
 		Digest:    d,
 		Size:      int64(len(content)),
 	}
@@ -88,7 +90,7 @@ func (s *Store) PutManifest(ctx context.Context, content []byte) (digest.Digest,
 	var header struct {
 		MediaType string `json:"mediaType"`
 	}
-	mediaType := "application/octet-stream"
+	mediaType := mediaTypeOctetStream
 	if err := json.Unmarshal(content, &header); err == nil && header.MediaType != "" {
 		mediaType = header.MediaType
 	}

--- a/oci/skills/store_test.go
+++ b/oci/skills/store_test.go
@@ -222,7 +222,7 @@ func TestStore_GetIndex(t *testing.T) {
 				MediaType: ocispec.MediaTypeImageManifest,
 				Digest:    digest.FromString("test"),
 				Size:      100,
-				Platform:  &ocispec.Platform{OS: "linux", Architecture: "amd64"},
+				Platform:  &ocispec.Platform{OS: OSLinux, Architecture: ArchAMD64},
 			},
 		},
 	}
@@ -239,8 +239,8 @@ func TestStore_GetIndex(t *testing.T) {
 	assert.Equal(t, 2, got.SchemaVersion)
 	assert.Equal(t, ocispec.MediaTypeImageIndex, got.MediaType)
 	require.Len(t, got.Manifests, 1)
-	assert.Equal(t, "linux", got.Manifests[0].Platform.OS)
-	assert.Equal(t, "amd64", got.Manifests[0].Platform.Architecture)
+	assert.Equal(t, OSLinux, got.Manifests[0].Platform.OS)
+	assert.Equal(t, ArchAMD64, got.Manifests[0].Platform.Architecture)
 }
 
 func TestStore_IsIndex(t *testing.T) {

--- a/oci/skills/tar_test.go
+++ b/oci/skills/tar_test.go
@@ -17,8 +17,8 @@ func TestCreateTar_Reproducible(t *testing.T) {
 	t.Parallel()
 
 	files := []FileEntry{
-		{Path: "b.txt", Content: []byte("content b")},
-		{Path: "a.txt", Content: []byte("content a")},
+		{Path: testFileB, Content: []byte("content b")},
+		{Path: testFileA, Content: []byte("content a")},
 		{Path: "c/d.txt", Content: []byte("content d")},
 	}
 
@@ -37,13 +37,13 @@ func TestCreateTar_DifferentOrder(t *testing.T) {
 	t.Parallel()
 
 	files1 := []FileEntry{
-		{Path: "b.txt", Content: []byte("b")},
-		{Path: "a.txt", Content: []byte("a")},
+		{Path: testFileB, Content: []byte("b")},
+		{Path: testFileA, Content: []byte("a")},
 	}
 
 	files2 := []FileEntry{
-		{Path: "a.txt", Content: []byte("a")},
-		{Path: "b.txt", Content: []byte("b")},
+		{Path: testFileA, Content: []byte("a")},
+		{Path: testFileB, Content: []byte("b")},
 	}
 
 	opts := DefaultTarOptions()
@@ -107,7 +107,7 @@ func TestExtractTar_RoundTrip(t *testing.T) {
 	t.Parallel()
 
 	originalFiles := []FileEntry{
-		{Path: "a.txt", Content: []byte("content a")},
+		{Path: testFileA, Content: []byte("content a")},
 		{Path: "b/c.txt", Content: []byte("content c")},
 	}
 

--- a/oci/skills/testconsts_test.go
+++ b/oci/skills/testconsts_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package skills
+
+const (
+	testFileA         = "a.txt"
+	testFileB         = "b.txt"
+	testSkillMySkill  = "my-skill"
+	testNotJSON       = "not-json"
+	testPlatformAMD64 = "linux/amd64"
+	testPlatformARMv7 = "linux/arm/v7"
+	testArchARM       = "arm"
+	testToolGrep      = "Grep"
+	testToolRead      = "Read"
+)

--- a/permissions/profile_privileged_test.go
+++ b/permissions/profile_privileged_test.go
@@ -22,7 +22,7 @@ func TestProfile_Privileged(t *testing.T) {
 		{
 			name: "Default profile should not be privileged",
 			profile: &Profile{
-				Name:       "test",
+				Name:       testProfileName,
 				Privileged: false,
 			},
 			expected: false,
@@ -30,7 +30,7 @@ func TestProfile_Privileged(t *testing.T) {
 		{
 			name: "Privileged profile should be privileged",
 			profile: &Profile{
-				Name:       "test",
+				Name:       testProfileName,
 				Privileged: true,
 			},
 			expected: true,
@@ -71,7 +71,7 @@ func TestProfile_PrivilegedJSONSerialization(t *testing.T) {
 		{
 			name: "Non-privileged profile JSON",
 			profile: &Profile{
-				Name:       "test",
+				Name:       testProfileName,
 				Privileged: false,
 			},
 			expected: `{"name":"test"}`, // privileged: false should be omitted due to omitempty
@@ -79,7 +79,7 @@ func TestProfile_PrivilegedJSONSerialization(t *testing.T) {
 		{
 			name: "Privileged profile JSON",
 			profile: &Profile{
-				Name:       "test",
+				Name:       testProfileName,
 				Privileged: true,
 			},
 			expected: `{"name":"test","privileged":true}`,

--- a/permissions/profile_test.go
+++ b/permissions/profile_test.go
@@ -11,6 +11,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testProfileName         = "test"
+	testNameSinglePath      = "Single path"
+	testNameHostToContainer = "Host path to container path"
+	testNameResourceURI     = "Resource URI"
+	pathDir                 = "/path/to/dir"
+	pathContainer           = "/container/path"
+	pathWindowsFooBar       = `C:\foo\bar`
+	mountHostToContainer    = "/host/path:/container/path"
+	mountVolume             = "volume://myvolume:/container/path"
+	mountSecret             = "secret://mysecret:/container/path"
+	mountInjection          = "/path/with/$(rm -rf *):/container/path"
+	mountTraversal          = "/path/with/../../../etc/passwd:/container/path"
+	mountVolumeRmrf         = "volume://$(rm -rf *):/container/path"
+)
+
 func TestMountDeclaration_Parse(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -21,10 +37,10 @@ func TestMountDeclaration_Parse(t *testing.T) {
 		expectError    bool
 	}{
 		{
-			name:           "Single path",
-			declaration:    "/path/to/dir",
-			expectedSource: "/path/to/dir",
-			expectedTarget: "/path/to/dir",
+			name:           testNameSinglePath,
+			declaration:    pathDir,
+			expectedSource: pathDir,
+			expectedTarget: pathDir,
 			expectError:    false,
 		},
 		{
@@ -33,51 +49,51 @@ func TestMountDeclaration_Parse(t *testing.T) {
 			// e.g. C:\foo -> /C:\\foo
 			// While this behaviour is unusual, it's valid, and we should support it.
 			name:           "Single path (Windows)",
-			declaration:    "C:\\foo\\bar",
-			expectedSource: "C:\\foo\\bar",
-			expectedTarget: "C:\\foo\\bar",
+			declaration:    pathWindowsFooBar,
+			expectedSource: pathWindowsFooBar,
+			expectedTarget: pathWindowsFooBar,
 			expectError:    false,
 		},
 		{
-			name:           "Host path to container path",
-			declaration:    "/host/path:/container/path",
+			name:           testNameHostToContainer,
+			declaration:    mountHostToContainer,
 			expectedSource: "/host/path",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
-			name:           "Resource URI",
-			declaration:    "volume://myvolume:/container/path",
+			name:           testNameResourceURI,
+			declaration:    mountVolume,
 			expectedSource: "volume://myvolume",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Resource URI (Windows)",
 			declaration:    "volume://C:\\Foo\\Bar:/container/path",
 			expectedSource: "volume://C:\\Foo\\Bar",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Resource URI (Windows forward slashes)",
 			declaration:    "volume://C:/Foo/Bar:/container/path",
 			expectedSource: "volume://C:/Foo/Bar",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Resource URI (Windows mixed slashes)",
 			declaration:    "volume://C:\\Foo/Bar:/container/path",
 			expectedSource: "volume://C:\\Foo/Bar",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Different resource URI",
-			declaration:    "secret://mysecret:/container/path",
+			declaration:    mountSecret,
 			expectedSource: "secret://mysecret",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
@@ -106,42 +122,42 @@ func TestMountDeclaration_Parse(t *testing.T) {
 			name:           "Path with spaces",
 			declaration:    "/path with spaces:/container/path",
 			expectedSource: "/path with spaces",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Path with special characters",
 			declaration:    "/path/with/special/chars!@#:/container/path",
 			expectedSource: "/path/with/special/chars!@#",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Path with Unicode characters",
 			declaration:    "/path/with/unicode/😀:/container/path",
 			expectedSource: "/path/with/unicode/😀",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Windows style path",
 			declaration:    "C:\\path\\to\\dir:/container/path",
 			expectedSource: "C:\\path\\to\\dir",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Windows style path (forward slashes)",
 			declaration:    "C:/path/to/dir:/container/path",
 			expectedSource: "C:/path/to/dir",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Windows style path (mixed slashes)",
 			declaration:    "C:\\path/to\\dir:/container/path", // Yes, this is allowed on Windows...
 			expectedSource: "C:\\path/to\\dir",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
@@ -168,36 +184,36 @@ func TestMountDeclaration_Parse(t *testing.T) {
 		{
 			name:           "Path with trailing slash",
 			declaration:    "/path/to/dir/:/container/path/",
-			expectedSource: "/path/to/dir",
-			expectedTarget: "/container/path",
+			expectedSource: pathDir,
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Path with multiple slashes",
 			declaration:    "/path//to///dir:/container//path",
-			expectedSource: "/path/to/dir",
-			expectedTarget: "/container/path",
+			expectedSource: pathDir,
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Path with Unicode characters",
 			declaration:    "/path/with/unicode/😀:/container/path",
 			expectedSource: "/path/with/unicode/😀",
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 		{
 			name:           "Path with potential command injection",
-			declaration:    "/path/with/$(rm -rf *):/container/path",
+			declaration:    mountInjection,
 			expectedSource: "",
 			expectedTarget: "",
 			expectError:    true, // Now expecting an error due to validation
 		},
 		{
 			name:           "Path with potential path traversal",
-			declaration:    "/path/with/../../../etc/passwd:/container/path",
+			declaration:    mountTraversal,
 			expectedSource: "/etc/passwd", // filepath.Clean resolves the path
-			expectedTarget: "/container/path",
+			expectedTarget: pathContainer,
 			expectError:    false,
 		},
 	}
@@ -227,18 +243,18 @@ func TestMountDeclaration_IsValid(t *testing.T) {
 		expected    bool
 	}{
 		{
-			name:        "Single path",
-			declaration: "/path/to/dir",
+			name:        testNameSinglePath,
+			declaration: pathDir,
 			expected:    true,
 		},
 		{
-			name:        "Host path to container path",
-			declaration: "/host/path:/container/path",
+			name:        testNameHostToContainer,
+			declaration: mountHostToContainer,
 			expected:    true,
 		},
 		{
-			name:        "Resource URI",
-			declaration: "volume://myvolume:/container/path",
+			name:        testNameResourceURI,
+			declaration: mountVolume,
 			expected:    true,
 		},
 		{
@@ -249,12 +265,12 @@ func TestMountDeclaration_IsValid(t *testing.T) {
 		// Security-focused tests
 		{
 			name:        "Path with potential command injection",
-			declaration: "/path/with/$(rm -rf *):/container/path",
+			declaration: mountInjection,
 			expected:    false, // Now invalid due to validation
 		},
 		{
 			name:        "Path with potential path traversal",
-			declaration: "/path/with/../../../etc/passwd:/container/path",
+			declaration: mountTraversal,
 			expected:    true, // Valid format, but potentially dangerous
 		},
 	}
@@ -275,23 +291,23 @@ func TestMountDeclaration_IsResourceURI(t *testing.T) {
 		expected    bool
 	}{
 		{
-			name:        "Single path",
-			declaration: "/path/to/dir",
+			name:        testNameSinglePath,
+			declaration: pathDir,
 			expected:    false,
 		},
 		{
-			name:        "Host path to container path",
-			declaration: "/host/path:/container/path",
+			name:        testNameHostToContainer,
+			declaration: mountHostToContainer,
 			expected:    false,
 		},
 		{
-			name:        "Resource URI",
-			declaration: "volume://myvolume:/container/path",
+			name:        testNameResourceURI,
+			declaration: mountVolume,
 			expected:    true,
 		},
 		{
 			name:        "Different resource URI",
-			declaration: "secret://mysecret:/container/path",
+			declaration: mountSecret,
 			expected:    true,
 		},
 		// Security-focused tests
@@ -302,7 +318,7 @@ func TestMountDeclaration_IsResourceURI(t *testing.T) {
 		},
 		{
 			name:        "Resource URI with potential command injection",
-			declaration: "volume://$(rm -rf *):/container/path",
+			declaration: mountVolumeRmrf,
 			expected:    true, // Valid format, but potentially dangerous
 		},
 	}
@@ -324,33 +340,33 @@ func TestMountDeclaration_GetResourceType(t *testing.T) {
 		expectError  bool
 	}{
 		{
-			name:         "Single path",
-			declaration:  "/path/to/dir",
+			name:         testNameSinglePath,
+			declaration:  pathDir,
 			expectedType: "",
 			expectError:  true,
 		},
 		{
-			name:         "Host path to container path",
-			declaration:  "/host/path:/container/path",
+			name:         testNameHostToContainer,
+			declaration:  mountHostToContainer,
 			expectedType: "",
 			expectError:  true,
 		},
 		{
 			name:         "Volume resource URI",
-			declaration:  "volume://myvolume:/container/path",
+			declaration:  mountVolume,
 			expectedType: "volume",
 			expectError:  false,
 		},
 		{
 			name:         "Secret resource URI",
-			declaration:  "secret://mysecret:/container/path",
+			declaration:  mountSecret,
 			expectedType: "secret",
 			expectError:  false,
 		},
 		// Security-focused tests
 		{
 			name:         "Resource URI with potential command injection",
-			declaration:  "volume://$(rm -rf *):/container/path",
+			declaration:  mountVolumeRmrf,
 			expectedType: "volume",
 			expectError:  false, // Valid format, but potentially dangerous
 		},
@@ -388,9 +404,9 @@ func TestParseMountDeclarations(t *testing.T) {
 		{
 			name: "Valid declarations",
 			declarations: []string{
-				"/path/to/dir",
-				"/host/path:/container/path",
-				"volume://myvolume:/container/path",
+				pathDir,
+				mountHostToContainer,
+				mountVolume,
 			},
 			expectError: false,
 		},
@@ -403,9 +419,9 @@ func TestParseMountDeclarations(t *testing.T) {
 		{
 			name: "Declarations with potential security issues",
 			declarations: []string{
-				"/path/with/$(rm -rf *):/container/path",
-				"volume://$(rm -rf *):/container/path",
-				"/path/with/../../../etc/passwd:/container/path",
+				mountInjection,
+				mountVolumeRmrf,
+				mountTraversal,
 			},
 			expectError: true, // Now expecting an error due to validation
 		},
@@ -434,11 +450,11 @@ func TestMountDeclaration_SecurityValidation(t *testing.T) {
 	// These tests check that our parsing is robust against various security issues
 
 	// Test for path traversal - this should be cleaned but allowed
-	traversalMount := MountDeclaration("/etc/passwd:/container/path")
+	traversalMount := MountDeclaration("/etc/passwd:" + pathContainer)
 	source, target, err := traversalMount.Parse()
 	require.NoError(t, err)
 	assert.Equal(t, "/etc/passwd", source)
-	assert.Equal(t, "/container/path", target)
+	assert.Equal(t, pathContainer, target)
 
 	// Test for command injection - this should be rejected
 	injectionMount := MountDeclaration("$(rm -rf *):/container/path")
@@ -463,11 +479,11 @@ func TestMountDeclaration_EdgeCases(t *testing.T) {
 
 	// Test with very long paths
 	longPath := "/very/long/path/" + strings.Repeat("a", 1000)
-	longMount := MountDeclaration(longPath + ":/container/path")
+	longMount := MountDeclaration(longPath + ":" + pathContainer)
 	source, target, err := longMount.Parse()
 	require.NoError(t, err)
 	assert.Equal(t, longPath, source)
-	assert.Equal(t, "/container/path", target)
+	assert.Equal(t, pathContainer, target)
 
 	// Test with path containing "://" but not at the beginning
 	pathWithColon := MountDeclaration("/some/other/path/://:/tmp/foo")

--- a/registry/converters/converters_fixture_test.go
+++ b/registry/converters/converters_fixture_test.go
@@ -35,7 +35,7 @@ func TestConverters_Fixtures(t *testing.T) {
 			fixtureDir:   "testdata/image_to_server",
 			inputFile:    "input_github.json",
 			expectedFile: "expected_github.json",
-			serverName:   "github",
+			serverName:   repoSourceGitHub,
 			convertFunc:  "ImageToServer",
 			validateFunc: validateImageToServerConversion,
 		},
@@ -177,7 +177,7 @@ func getServerJSONExtensions(t *testing.T, serverJSON *upstream.ServerJSON, key 
 		return nil
 	}
 
-	stacklokData, ok := serverJSON.Meta.PublisherProvided["io.github.stacklok"].(map[string]interface{})
+	stacklokData, ok := serverJSON.Meta.PublisherProvided[testNamespace].(map[string]interface{})
 	if !ok {
 		return nil
 	}
@@ -214,8 +214,8 @@ func validateImageToServerConversion(t *testing.T, inputData, outputData []byte)
 	require.NotNil(t, extensions, "Extensions should exist for image")
 
 	// Verify key extension fields
-	assert.Equal(t, input.Status, extensions["status"], "Status should be in extensions")
-	assert.Equal(t, input.Tier, extensions["tier"], "Tier should be in extensions")
+	assert.Equal(t, input.Status, extensions[statusKey], "Status should be in extensions")
+	assert.Equal(t, input.Tier, extensions[tierKey], "Tier should be in extensions")
 	assert.NotNil(t, extensions["tools"], "Tools should be in extensions")
 	assert.NotNil(t, extensions["tags"], "Tags should be in extensions")
 

--- a/registry/converters/converters_test.go
+++ b/registry/converters/converters_test.go
@@ -25,15 +25,15 @@ func createTestServerJSON() *upstream.ServerJSON {
 		Name:        "io.github.stacklok/test-server",
 		Title:       "Test Server",
 		Description: "Test MCP server",
-		Version:     "1.0.0",
+		Version:     testVersion,
 		Repository: &model.Repository{
 			URL:    "https://github.com/test/repo",
-			Source: "github",
+			Source: repoSourceGitHub,
 		},
 		Packages: []model.Package{
 			{
 				RegistryType: model.RegistryTypeOCI,
-				Identifier:   "ghcr.io/test/server:latest",
+				Identifier:   testImageRef,
 				Transport: model.Transport{
 					Type: model.TransportTypeStdio,
 				},
@@ -41,16 +41,16 @@ func createTestServerJSON() *upstream.ServerJSON {
 		},
 		Meta: &upstream.ServerMeta{
 			PublisherProvided: map[string]interface{}{
-				"io.github.stacklok": map[string]interface{}{
-					"ghcr.io/test/server:latest": map[string]interface{}{
-						"status":   "active",
-						"tier":     "Official",
-						"tools":    []interface{}{"tool1", "tool2"},
-						"tags":     []interface{}{"test", "example"},
+				testNamespace: map[string]interface{}{
+					testImageRef: map[string]interface{}{
+						statusKey:  defaultStatus,
+						tierKey:    testTier,
+						toolsKey:   []interface{}{testToolName, testToolNameAlt},
+						"tags":     []interface{}{testName, testCategory},
 						"overview": "# Test Server\n\nA test MCP server.",
 						"tool_definitions": []interface{}{
 							map[string]interface{}{
-								"name":        "tool1",
+								"name":        testToolName,
 								"description": "First tool",
 							},
 						},
@@ -73,20 +73,20 @@ func createTestImageMetadata() *registry.ImageMetadata {
 			Description:   "Test MCP server",
 			Transport:     model.TransportTypeStdio,
 			RepositoryURL: "https://github.com/test/repo",
-			Status:        "active",
-			Tier:          "Official",
-			Tools:         []string{"tool1", "tool2"},
-			Tags:          []string{"test", "example"},
+			Status:        defaultStatus,
+			Tier:          testTier,
+			Tools:         []string{testToolName, testToolNameAlt},
+			Tags:          []string{testName, testCategory},
 			Overview:      "# Test Server\n\nA test MCP server.",
 			ToolDefinitions: []mcp.Tool{
-				{Name: "tool1", Description: "First tool"},
+				{Name: testToolName, Description: "First tool"},
 			},
 			Metadata: &registry.Metadata{
 				Stars:       100,
 				LastUpdated: "2025-01-01",
 			},
 		},
-		Image: "ghcr.io/test/server:latest",
+		Image: testImageRef,
 	}
 }
 
@@ -96,18 +96,18 @@ func createTestRemoteServerMetadata() *registry.RemoteServerMetadata {
 		BaseServerMetadata: registry.BaseServerMetadata{
 			Title:         "Test Remote",
 			Description:   "Test remote server",
-			Transport:     "sse",
+			Transport:     testTransportSSE,
 			RepositoryURL: "https://github.com/test/remote",
-			Status:        "active",
-			Tier:          "Official",
-			Tools:         []string{"tool1"},
+			Status:        defaultStatus,
+			Tier:          testTier,
+			Tools:         []string{testToolName},
 			Tags:          []string{"remote"},
 			Overview:      "# Test Remote\n\nA test remote server.",
 			ToolDefinitions: []mcp.Tool{
-				{Name: "tool1", Description: "Remote tool"},
+				{Name: testToolName, Description: "Remote tool"},
 			},
 		},
-		URL: "https://api.example.com/mcp",
+		URL: testRemoteURL,
 	}
 }
 
@@ -122,18 +122,18 @@ func TestServerJSONToImageMetadata_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, imageMetadata)
 
-	assert.Equal(t, "ghcr.io/test/server:latest", imageMetadata.Image)
+	assert.Equal(t, testImageRef, imageMetadata.Image)
 	assert.Equal(t, "Test Server", imageMetadata.Title)
 	assert.Equal(t, "Test MCP server", imageMetadata.Description)
 	assert.Equal(t, model.TransportTypeStdio, imageMetadata.Transport)
 	assert.Equal(t, "https://github.com/test/repo", imageMetadata.RepositoryURL)
-	assert.Equal(t, "active", imageMetadata.Status)
-	assert.Equal(t, "Official", imageMetadata.Tier)
-	assert.Equal(t, []string{"tool1", "tool2"}, imageMetadata.Tools)
-	assert.Equal(t, []string{"test", "example"}, imageMetadata.Tags)
+	assert.Equal(t, defaultStatus, imageMetadata.Status)
+	assert.Equal(t, testTier, imageMetadata.Tier)
+	assert.Equal(t, []string{testToolName, testToolNameAlt}, imageMetadata.Tools)
+	assert.Equal(t, []string{testName, testCategory}, imageMetadata.Tags)
 	assert.Equal(t, "# Test Server\n\nA test MCP server.", imageMetadata.Overview)
 	require.Len(t, imageMetadata.ToolDefinitions, 1)
-	assert.Equal(t, "tool1", imageMetadata.ToolDefinitions[0].Name)
+	assert.Equal(t, testToolName, imageMetadata.ToolDefinitions[0].Name)
 	assert.NotNil(t, imageMetadata.Metadata)
 	assert.Equal(t, 100, imageMetadata.Metadata.Stars)
 	assert.Equal(t, "2025-01-01", imageMetadata.Metadata.LastUpdated)
@@ -153,7 +153,7 @@ func TestServerJSONToImageMetadata_NoPackages(t *testing.T) {
 	t.Parallel()
 
 	serverJSON := &upstream.ServerJSON{
-		Name:     "test",
+		Name:     testName,
 		Packages: []model.Package{},
 	}
 
@@ -168,7 +168,7 @@ func TestServerJSONToImageMetadata_NoOCIPackages(t *testing.T) {
 	t.Parallel()
 
 	serverJSON := &upstream.ServerJSON{
-		Name: "test",
+		Name: testName,
 		Packages: []model.Package{
 			{
 				RegistryType: "npm",
@@ -188,7 +188,7 @@ func TestServerJSONToImageMetadata_MultipleOCIPackages(t *testing.T) {
 	t.Parallel()
 
 	serverJSON := &upstream.ServerJSON{
-		Name: "test",
+		Name: testName,
 		Packages: []model.Package{
 			{
 				RegistryType: model.RegistryTypeOCI,
@@ -214,18 +214,18 @@ func TestServerJSONToImageMetadata_WithEnvVars(t *testing.T) {
 	serverJSON := createTestServerJSON()
 	serverJSON.Packages[0].EnvironmentVariables = []model.KeyValueInput{
 		{
-			Name: "API_KEY",
+			Name: envAPIKey,
 			InputWithVariables: model.InputWithVariables{
 				Input: model.Input{
 					Description: "API Key",
 					IsRequired:  true,
 					IsSecret:    true,
-					Default:     "default-key",
+					Default:     envValueDefault,
 				},
 			},
 		},
 		{
-			Name: "DEBUG",
+			Name: envDebug,
 			InputWithVariables: model.InputWithVariables{
 				Input: model.Input{
 					Description: "Debug mode",
@@ -243,13 +243,13 @@ func TestServerJSONToImageMetadata_WithEnvVars(t *testing.T) {
 	require.NotNil(t, imageMetadata)
 	require.Len(t, imageMetadata.EnvVars, 2)
 
-	assert.Equal(t, "API_KEY", imageMetadata.EnvVars[0].Name)
+	assert.Equal(t, envAPIKey, imageMetadata.EnvVars[0].Name)
 	assert.Equal(t, "API Key", imageMetadata.EnvVars[0].Description)
 	assert.True(t, imageMetadata.EnvVars[0].Required)
 	assert.True(t, imageMetadata.EnvVars[0].Secret)
-	assert.Equal(t, "default-key", imageMetadata.EnvVars[0].Default)
+	assert.Equal(t, envValueDefault, imageMetadata.EnvVars[0].Default)
 
-	assert.Equal(t, "DEBUG", imageMetadata.EnvVars[1].Name)
+	assert.Equal(t, envDebug, imageMetadata.EnvVars[1].Name)
 	assert.Equal(t, "Debug mode", imageMetadata.EnvVars[1].Description)
 	assert.False(t, imageMetadata.EnvVars[1].Required)
 	assert.False(t, imageMetadata.EnvVars[1].Secret)
@@ -320,11 +320,11 @@ func TestImageMetadataToServerJSON_Success(t *testing.T) {
 	assert.Equal(t, "io.github.stacklok/test-server", serverJSON.Name)
 	assert.Equal(t, "Test Server", serverJSON.Title)
 	assert.Equal(t, "Test MCP server", serverJSON.Description)
-	assert.Equal(t, "1.0.0", serverJSON.Version)
+	assert.Equal(t, testVersion, serverJSON.Version)
 	assert.Equal(t, "https://github.com/test/repo", serverJSON.Repository.URL)
 	assert.Len(t, serverJSON.Packages, 1)
 	assert.Equal(t, model.RegistryTypeOCI, serverJSON.Packages[0].RegistryType)
-	assert.Equal(t, "ghcr.io/test/server:latest", serverJSON.Packages[0].Identifier)
+	assert.Equal(t, testImageRef, serverJSON.Packages[0].Identifier)
 	assert.NotNil(t, serverJSON.Meta)
 	assert.NotNil(t, serverJSON.Meta.PublisherProvided)
 }
@@ -332,7 +332,7 @@ func TestImageMetadataToServerJSON_Success(t *testing.T) {
 func TestImageMetadataToServerJSON_NilInput(t *testing.T) {
 	t.Parallel()
 
-	serverJSON, err := ImageMetadataToServerJSON("test", nil)
+	serverJSON, err := ImageMetadataToServerJSON(testName, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, serverJSON)
@@ -356,7 +356,7 @@ func TestImageMetadataToServerJSON_WithEnvVars(t *testing.T) {
 	imageMetadata := createTestImageMetadata()
 	imageMetadata.EnvVars = []*registry.EnvVar{
 		{
-			Name:        "API_KEY",
+			Name:        envAPIKey,
 			Description: "API Key",
 			Required:    true,
 			Secret:      true,
@@ -364,7 +364,7 @@ func TestImageMetadataToServerJSON_WithEnvVars(t *testing.T) {
 		},
 	}
 
-	serverJSON, err := ImageMetadataToServerJSON("test", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testName, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
@@ -372,7 +372,7 @@ func TestImageMetadataToServerJSON_WithEnvVars(t *testing.T) {
 	require.Len(t, serverJSON.Packages[0].EnvironmentVariables, 1)
 
 	envVar := serverJSON.Packages[0].EnvironmentVariables[0]
-	assert.Equal(t, "API_KEY", envVar.Name)
+	assert.Equal(t, envAPIKey, envVar.Name)
 	assert.Equal(t, "API Key", envVar.Description)
 	assert.True(t, envVar.IsRequired)
 	assert.True(t, envVar.IsSecret)
@@ -386,7 +386,7 @@ func TestImageMetadataToServerJSON_WithTargetPort(t *testing.T) {
 	imageMetadata.Transport = model.TransportTypeStreamableHTTP
 	imageMetadata.TargetPort = 9090
 
-	serverJSON, err := ImageMetadataToServerJSON("test", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testName, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
@@ -403,7 +403,7 @@ func TestImageMetadataToServerJSON_HTTPTransportNoPort(t *testing.T) {
 	imageMetadata.Transport = model.TransportTypeStreamableHTTP
 	imageMetadata.TargetPort = 0 // No port specified
 
-	serverJSON, err := ImageMetadataToServerJSON("test", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testName, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
@@ -419,7 +419,7 @@ func TestImageMetadataToServerJSON_StdioTransport(t *testing.T) {
 	imageMetadata := createTestImageMetadata()
 	imageMetadata.Transport = model.TransportTypeStdio
 
-	serverJSON, err := ImageMetadataToServerJSON("test", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testName, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
@@ -435,7 +435,7 @@ func TestImageMetadataToServerJSON_EmptyTransportDefaultsToStdio(t *testing.T) {
 	imageMetadata := createTestImageMetadata()
 	imageMetadata.Transport = ""
 
-	serverJSON, err := ImageMetadataToServerJSON("test", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testName, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
@@ -448,21 +448,21 @@ func TestImageMetadataToServerJSON_WithPublisherExtensions(t *testing.T) {
 	t.Parallel()
 
 	imageMetadata := createTestImageMetadata()
-	serverJSON, err := ImageMetadataToServerJSON("test", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testName, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
 	require.NotNil(t, serverJSON.Meta)
 	require.NotNil(t, serverJSON.Meta.PublisherProvided)
 
-	stacklokData, ok := serverJSON.Meta.PublisherProvided["io.github.stacklok"].(map[string]interface{})
+	stacklokData, ok := serverJSON.Meta.PublisherProvided[testNamespace].(map[string]interface{})
 	require.True(t, ok)
 
-	imageData, ok := stacklokData["ghcr.io/test/server:latest"].(map[string]interface{})
+	imageData, ok := stacklokData[testImageRef].(map[string]interface{})
 	require.True(t, ok)
 
-	assert.Equal(t, "active", imageData["status"])
-	assert.Equal(t, "Official", imageData["tier"])
+	assert.Equal(t, defaultStatus, imageData[statusKey])
+	assert.Equal(t, testTier, imageData[tierKey])
 }
 
 func TestImageMetadataToServerJSON_EmptyStatusDefaultsToActive(t *testing.T) {
@@ -471,18 +471,18 @@ func TestImageMetadataToServerJSON_EmptyStatusDefaultsToActive(t *testing.T) {
 	imageMetadata := createTestImageMetadata()
 	imageMetadata.Status = "" // Empty status should default to "active"
 
-	serverJSON, err := ImageMetadataToServerJSON("test", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testName, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
 
-	stacklokData, ok := serverJSON.Meta.PublisherProvided["io.github.stacklok"].(map[string]interface{})
+	stacklokData, ok := serverJSON.Meta.PublisherProvided[testNamespace].(map[string]interface{})
 	require.True(t, ok)
 
-	imageData, ok := stacklokData["ghcr.io/test/server:latest"].(map[string]interface{})
+	imageData, ok := stacklokData[testImageRef].(map[string]interface{})
 	require.True(t, ok)
 
-	assert.Equal(t, "active", imageData["status"])
+	assert.Equal(t, defaultStatus, imageData[statusKey])
 }
 
 func TestRemoteServerMetadataToServerJSON_EmptyStatusDefaultsToActive(t *testing.T) {
@@ -496,24 +496,24 @@ func TestRemoteServerMetadataToServerJSON_EmptyStatusDefaultsToActive(t *testing
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
 
-	stacklokData, ok := serverJSON.Meta.PublisherProvided["io.github.stacklok"].(map[string]interface{})
+	stacklokData, ok := serverJSON.Meta.PublisherProvided[testNamespace].(map[string]interface{})
 	require.True(t, ok)
 
-	remoteData, ok := stacklokData["https://api.example.com/mcp"].(map[string]interface{})
+	remoteData, ok := stacklokData[testRemoteURL].(map[string]interface{})
 	require.True(t, ok)
 
-	assert.Equal(t, "active", remoteData["status"])
+	assert.Equal(t, defaultStatus, remoteData[statusKey])
 }
 
 func TestImageMetadataToServerJSON_ReverseDNSName(t *testing.T) {
 	t.Parallel()
 
 	imageMetadata := createTestImageMetadata()
-	serverJSON, err := ImageMetadataToServerJSON("fetch", imageMetadata)
+	serverJSON, err := ImageMetadataToServerJSON(testServerNameFetch, imageMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
-	assert.Equal(t, "io.github.stacklok/fetch", serverJSON.Name)
+	assert.Equal(t, testServerNameFetchFQ, serverJSON.Name)
 }
 
 // Test Suite 3: ServerJSONToRemoteServerMetadata
@@ -522,7 +522,7 @@ func TestServerJSONToRemoteServerMetadata_Success(t *testing.T) {
 	t.Parallel()
 
 	serverJSON := &upstream.ServerJSON{
-		Name:        "io.github.stacklok/test-remote",
+		Name:        testNamespace + "/test-remote",
 		Title:       "Test Remote",
 		Description: "Test remote server",
 		Repository: &model.Repository{
@@ -530,21 +530,21 @@ func TestServerJSONToRemoteServerMetadata_Success(t *testing.T) {
 		},
 		Remotes: []model.Transport{
 			{
-				Type: "sse",
-				URL:  "https://api.example.com/mcp",
+				Type: testTransportSSE,
+				URL:  testRemoteURL,
 			},
 		},
 		Meta: &upstream.ServerMeta{
 			PublisherProvided: map[string]interface{}{
-				"io.github.stacklok": map[string]interface{}{
-					"https://api.example.com/mcp": map[string]interface{}{
-						"status":   "active",
-						"tier":     "Official",
-						"tools":    []interface{}{"tool1"},
+				testNamespace: map[string]interface{}{
+					testRemoteURL: map[string]interface{}{
+						statusKey:  defaultStatus,
+						tierKey:    testTier,
+						toolsKey:   []interface{}{testToolName},
 						"overview": "# Test Remote\n\nA test remote server.",
 						"tool_definitions": []interface{}{
 							map[string]interface{}{
-								"name":        "tool1",
+								"name":        testToolName,
 								"description": "Remote tool",
 							},
 						},
@@ -559,17 +559,17 @@ func TestServerJSONToRemoteServerMetadata_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, remoteMetadata)
 
-	assert.Equal(t, "https://api.example.com/mcp", remoteMetadata.URL)
+	assert.Equal(t, testRemoteURL, remoteMetadata.URL)
 	assert.Equal(t, "Test Remote", remoteMetadata.Title)
 	assert.Equal(t, "Test remote server", remoteMetadata.Description)
-	assert.Equal(t, "sse", remoteMetadata.Transport)
+	assert.Equal(t, testTransportSSE, remoteMetadata.Transport)
 	assert.Equal(t, "https://github.com/test/remote", remoteMetadata.RepositoryURL)
-	assert.Equal(t, "active", remoteMetadata.Status)
-	assert.Equal(t, "Official", remoteMetadata.Tier)
-	assert.Equal(t, []string{"tool1"}, remoteMetadata.Tools)
+	assert.Equal(t, defaultStatus, remoteMetadata.Status)
+	assert.Equal(t, testTier, remoteMetadata.Tier)
+	assert.Equal(t, []string{testToolName}, remoteMetadata.Tools)
 	assert.Equal(t, "# Test Remote\n\nA test remote server.", remoteMetadata.Overview)
 	require.Len(t, remoteMetadata.ToolDefinitions, 1)
-	assert.Equal(t, "tool1", remoteMetadata.ToolDefinitions[0].Name)
+	assert.Equal(t, testToolName, remoteMetadata.ToolDefinitions[0].Name)
 }
 
 func TestServerJSONToRemoteServerMetadata_NilInput(t *testing.T) {
@@ -586,7 +586,7 @@ func TestServerJSONToRemoteServerMetadata_NoRemotes(t *testing.T) {
 	t.Parallel()
 
 	serverJSON := &upstream.ServerJSON{
-		Name:    "test",
+		Name:    testName,
 		Remotes: []model.Transport{},
 	}
 
@@ -601,18 +601,18 @@ func TestServerJSONToRemoteServerMetadata_WithHeaders(t *testing.T) {
 	t.Parallel()
 
 	serverJSON := &upstream.ServerJSON{
-		Name:        "test",
+		Name:        testName,
 		Description: "Test",
 		Remotes: []model.Transport{
 			{
-				Type: "sse",
+				Type: testTransportSSE,
 				URL:  "https://api.example.com",
 				Headers: []model.KeyValueInput{
 					{
 						Name: "Authorization",
 						InputWithVariables: model.InputWithVariables{
 							Input: model.Input{
-								Description: "Auth token",
+								Description: envDescAuthToken,
 								IsRequired:  true,
 								IsSecret:    true,
 							},
@@ -630,7 +630,7 @@ func TestServerJSONToRemoteServerMetadata_WithHeaders(t *testing.T) {
 	require.Len(t, remoteMetadata.Headers, 1)
 
 	assert.Equal(t, "Authorization", remoteMetadata.Headers[0].Name)
-	assert.Equal(t, "Auth token", remoteMetadata.Headers[0].Description)
+	assert.Equal(t, envDescAuthToken, remoteMetadata.Headers[0].Description)
 	assert.True(t, remoteMetadata.Headers[0].Required)
 	assert.True(t, remoteMetadata.Headers[0].Secret)
 }
@@ -639,11 +639,11 @@ func TestServerJSONToRemoteServerMetadata_MissingPublisherExtensions(t *testing.
 	t.Parallel()
 
 	serverJSON := &upstream.ServerJSON{
-		Name:        "test",
+		Name:        testName,
 		Description: "Test",
 		Remotes: []model.Transport{
 			{
-				Type: "sse",
+				Type: testTransportSSE,
 				URL:  "https://api.example.com",
 			},
 		},
@@ -675,14 +675,14 @@ func TestRemoteServerMetadataToServerJSON_Success(t *testing.T) {
 	assert.Equal(t, "Test remote server", serverJSON.Description)
 	assert.Equal(t, "https://github.com/test/remote", serverJSON.Repository.URL)
 	assert.Len(t, serverJSON.Remotes, 1)
-	assert.Equal(t, "sse", serverJSON.Remotes[0].Type)
-	assert.Equal(t, "https://api.example.com/mcp", serverJSON.Remotes[0].URL)
+	assert.Equal(t, testTransportSSE, serverJSON.Remotes[0].Type)
+	assert.Equal(t, testRemoteURL, serverJSON.Remotes[0].URL)
 }
 
 func TestRemoteServerMetadataToServerJSON_NilInput(t *testing.T) {
 	t.Parallel()
 
-	serverJSON, err := RemoteServerMetadataToServerJSON("test", nil)
+	serverJSON, err := RemoteServerMetadataToServerJSON(testName, nil)
 
 	assert.Error(t, err)
 	assert.Nil(t, serverJSON)
@@ -713,7 +713,7 @@ func TestRemoteServerMetadataToServerJSON_WithHeaders(t *testing.T) {
 		},
 	}
 
-	serverJSON, err := RemoteServerMetadataToServerJSON("test", remoteMetadata)
+	serverJSON, err := RemoteServerMetadataToServerJSON(testName, remoteMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
@@ -731,21 +731,21 @@ func TestRemoteServerMetadataToServerJSON_WithPublisherExtensions(t *testing.T) 
 	t.Parallel()
 
 	remoteMetadata := createTestRemoteServerMetadata()
-	serverJSON, err := RemoteServerMetadataToServerJSON("test", remoteMetadata)
+	serverJSON, err := RemoteServerMetadataToServerJSON(testName, remoteMetadata)
 
 	require.NoError(t, err)
 	require.NotNil(t, serverJSON)
 	require.NotNil(t, serverJSON.Meta)
 	require.NotNil(t, serverJSON.Meta.PublisherProvided)
 
-	stacklokData, ok := serverJSON.Meta.PublisherProvided["io.github.stacklok"].(map[string]interface{})
+	stacklokData, ok := serverJSON.Meta.PublisherProvided[testNamespace].(map[string]interface{})
 	require.True(t, ok)
 
-	remoteData, ok := stacklokData["https://api.example.com/mcp"].(map[string]interface{})
+	remoteData, ok := stacklokData[testRemoteURL].(map[string]interface{})
 	require.True(t, ok)
 
-	assert.Equal(t, "active", remoteData["status"])
-	assert.Equal(t, "Official", remoteData["tier"])
+	assert.Equal(t, defaultStatus, remoteData[statusKey])
+	assert.Equal(t, testTier, remoteData[tierKey])
 }
 
 // Test Suite 5: Utility Functions
@@ -760,18 +760,18 @@ func TestExtractServerName(t *testing.T) {
 	}{
 		{
 			name:     "reverse DNS format",
-			input:    "io.github.stacklok/fetch",
-			expected: "fetch",
+			input:    testServerNameFetchFQ,
+			expected: testServerNameFetch,
 		},
 		{
 			name:     "no slash",
-			input:    "fetch",
-			expected: "fetch",
+			input:    testServerNameFetch,
+			expected: testServerNameFetch,
 		},
 		{
 			name:     "returns original if multiple slashes",
-			input:    "io.github.stacklok/mcp/server",
-			expected: "io.github.stacklok/mcp/server", // Function only splits on first slash, returns original if not exactly 2 parts
+			input:    testNamespace + "/mcp/server",
+			expected: testNamespace + "/mcp/server", // Function only splits on first slash, returns original if not exactly 2 parts
 		},
 	}
 
@@ -794,13 +794,13 @@ func TestBuildReverseDNSName(t *testing.T) {
 	}{
 		{
 			name:     "simple name",
-			input:    "fetch",
-			expected: "io.github.stacklok/fetch",
+			input:    testServerNameFetch,
+			expected: testServerNameFetchFQ,
 		},
 		{
 			name:     "already formatted",
-			input:    "io.github.stacklok/fetch",
-			expected: "io.github.stacklok/fetch",
+			input:    testServerNameFetchFQ,
+			expected: testServerNameFetchFQ,
 		},
 		{
 			name:     "other namespace",
@@ -891,9 +891,9 @@ func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 			Description:   "Full featured server",
 			Transport:     model.TransportTypeStreamableHTTP,
 			RepositoryURL: "https://github.com/test/full",
-			Status:        "active",
-			Tier:          "Official",
-			Tools:         []string{"tool1", "tool2", "tool3"},
+			Status:        defaultStatus,
+			Tier:          testTier,
+			Tools:         []string{testToolName, testToolNameAlt, "tool3"},
 			Tags:          []string{"tag1", "tag2"},
 			Metadata: &registry.Metadata{
 				Stars:       500,
@@ -904,7 +904,7 @@ func TestRoundTrip_ImageMetadataWithAllFields(t *testing.T) {
 		TargetPort: 8080,
 		EnvVars: []*registry.EnvVar{
 			{
-				Name:        "API_KEY",
+				Name:        envAPIKey,
 				Description: "API Key for authentication",
 				Required:    true,
 				Secret:      true,
@@ -990,11 +990,11 @@ func TestRealWorld_GitHubServer(t *testing.T) {
 		},
 		Meta: &upstream.ServerMeta{
 			PublisherProvided: map[string]interface{}{
-				"io.github.stacklok": map[string]interface{}{
+				testNamespace: map[string]interface{}{
 					"ghcr.io/github/github-mcp-server:0.19.1": map[string]interface{}{
-						"status": "active",
-						"tier":   "Official",
-						"tools": []interface{}{
+						statusKey: defaultStatus,
+						tierKey:   testTier,
+						toolsKey: []interface{}{
 							"add_comment_to_pending_review", "add_issue_comment", "add_sub_issue",
 							"assign_copilot_to_issue", "create_branch", "create_issue",
 							"create_or_update_file", "create_pull_request", "create_repository",
@@ -1043,8 +1043,8 @@ func TestRealWorld_GitHubServer(t *testing.T) {
 	assert.True(t, imageMetadata.EnvVars[0].Secret)
 
 	// Verify publisher extensions were extracted
-	assert.Equal(t, "active", imageMetadata.Status)
-	assert.Equal(t, "Official", imageMetadata.Tier)
+	assert.Equal(t, defaultStatus, imageMetadata.Status)
+	assert.Equal(t, testTier, imageMetadata.Tier)
 	require.Len(t, imageMetadata.Tools, 46, "Should have 46 tools")
 	assert.Contains(t, imageMetadata.Tools, "create_pull_request")
 	assert.Contains(t, imageMetadata.Tools, "search_repositories")
@@ -1076,17 +1076,17 @@ func TestRealWorld_GitHubServer(t *testing.T) {
 	// Verify publisher extensions are present in round-trip
 	require.NotNil(t, resultServerJSON.Meta)
 	require.NotNil(t, resultServerJSON.Meta.PublisherProvided)
-	stacklokData, ok := resultServerJSON.Meta.PublisherProvided["io.github.stacklok"].(map[string]interface{})
+	stacklokData, ok := resultServerJSON.Meta.PublisherProvided[testNamespace].(map[string]interface{})
 	require.True(t, ok, "Should have io.github.stacklok namespace")
 	imageData, ok := stacklokData["ghcr.io/github/github-mcp-server:0.19.1"].(map[string]interface{})
 	require.True(t, ok, "Should have image-specific extensions")
 
 	// Verify extensions preserved
-	assert.Equal(t, "active", imageData["status"])
-	assert.Equal(t, "Official", imageData["tier"])
+	assert.Equal(t, defaultStatus, imageData[statusKey])
+	assert.Equal(t, testTier, imageData[tierKey])
 
 	// Verify tools are preserved as interface slice
-	tools, ok := imageData["tools"].([]interface{})
+	tools, ok := imageData[toolsKey].([]interface{})
 	require.True(t, ok, "Tools should be []interface{}")
 	assert.Len(t, tools, 46)
 
@@ -1278,15 +1278,15 @@ func TestRealWorld_GitHubServer_ExactData(t *testing.T) {
 	// Verify publisher extensions contain all the extra data
 	require.NotNil(t, serverJSON.Meta)
 	require.NotNil(t, serverJSON.Meta.PublisherProvided)
-	stacklokData, ok := serverJSON.Meta.PublisherProvided["io.github.stacklok"].(map[string]interface{})
+	stacklokData, ok := serverJSON.Meta.PublisherProvided[testNamespace].(map[string]interface{})
 	require.True(t, ok)
 	extensions, ok := stacklokData["ghcr.io/github/github-mcp-server:v0.19.1"].(map[string]interface{})
 	require.True(t, ok)
 
 	// Verify extensions
-	assert.Equal(t, "Active", extensions["status"])
-	assert.Equal(t, "Official", extensions["tier"])
-	assert.NotNil(t, extensions["tools"])
+	assert.Equal(t, "Active", extensions[statusKey])
+	assert.Equal(t, testTier, extensions[tierKey])
+	assert.NotNil(t, extensions[toolsKey])
 	assert.NotNil(t, extensions["tags"])
 	assert.NotNil(t, extensions["metadata"])
 	assert.NotNil(t, extensions["permissions"])

--- a/registry/converters/envvar_extraction_test.go
+++ b/registry/converters/envvar_extraction_test.go
@@ -29,11 +29,11 @@ func TestExtractEnvFromRuntimeArgs(t *testing.T) {
 					InputWithVariables: model.InputWithVariables{
 						Input: model.Input{
 							Value:       "GITHUB_PERSONAL_ACCESS_TOKEN={token}",
-							Description: "Set an environment variable in the runtime",
+							Description: envDescRuntime,
 							IsRequired:  true,
 						},
 						Variables: map[string]model.Input{
-							"token": {
+							valueToken: {
 								IsRequired: true,
 								IsSecret:   true,
 								Format:     "string",
@@ -47,7 +47,7 @@ func TestExtractEnvFromRuntimeArgs(t *testing.T) {
 			expected: []*types.EnvVar{
 				{
 					Name:        "GITHUB_PERSONAL_ACCESS_TOKEN",
-					Description: "Set an environment variable in the runtime",
+					Description: envDescRuntime,
 					Required:    true,
 					Secret:      true,
 				},
@@ -59,8 +59,8 @@ func TestExtractEnvFromRuntimeArgs(t *testing.T) {
 				{
 					InputWithVariables: model.InputWithVariables{
 						Input: model.Input{
-							Value:       "API_KEY={key}",
-							Description: "API key",
+							Value:       envAPIKey + "={key}",
+							Description: envDescAPIKey,
 							IsRequired:  true,
 						},
 						Variables: map[string]model.Input{
@@ -76,7 +76,7 @@ func TestExtractEnvFromRuntimeArgs(t *testing.T) {
 				{
 					InputWithVariables: model.InputWithVariables{
 						Input: model.Input{
-							Value:       "DEBUG=true",
+							Value:       envDebug + "=" + envValueTrue,
 							Description: "Enable debug mode",
 							IsRequired:  false,
 						},
@@ -87,16 +87,16 @@ func TestExtractEnvFromRuntimeArgs(t *testing.T) {
 			},
 			expected: []*types.EnvVar{
 				{
-					Name:        "API_KEY",
-					Description: "API key",
+					Name:        envAPIKey,
+					Description: envDescAPIKey,
 					Required:    true,
 					Secret:      true,
 				},
 				{
-					Name:        "DEBUG",
+					Name:        envDebug,
 					Description: "Enable debug mode",
 					Required:    false,
-					Default:     "true",
+					Default:     envValueTrue,
 				},
 			},
 		},
@@ -106,12 +106,12 @@ func TestExtractEnvFromRuntimeArgs(t *testing.T) {
 				{
 					InputWithVariables: model.InputWithVariables{
 						Input: model.Input{
-							Value:       "TOKEN={token}",
-							Description: "Auth token",
+							Value:       envTokenTpl,
+							Description: envDescAuthToken,
 							IsRequired:  true,
 						},
 						Variables: map[string]model.Input{
-							"token": {
+							valueToken: {
 								IsRequired: true,
 								IsSecret:   true,
 							},
@@ -123,8 +123,8 @@ func TestExtractEnvFromRuntimeArgs(t *testing.T) {
 			},
 			expected: []*types.EnvVar{
 				{
-					Name:        "TOKEN",
-					Description: "Auth token",
+					Name:        envToken,
+					Description: envDescAuthToken,
 					Required:    true,
 					Secret:      true,
 				},
@@ -207,42 +207,42 @@ func TestParseEnvVarFromValue(t *testing.T) {
 	}{
 		{
 			name:        "static value",
-			value:       "DEBUG=true",
+			value:       envDebug + "=" + envValueTrue,
 			description: "Enable debug",
 			variables:   nil,
 			expected: &types.EnvVar{
-				Name:        "DEBUG",
+				Name:        envDebug,
 				Description: "Enable debug",
-				Default:     "true",
+				Default:     envValueTrue,
 			},
 		},
 		{
 			name:        "variable reference with metadata",
-			value:       "API_KEY={key}",
-			description: "API key",
+			value:       envAPIKey + "={key}",
+			description: envDescAPIKey,
 			variables: map[string]model.Input{
 				"key": {
 					IsRequired: true,
 					IsSecret:   true,
-					Default:    "default-key",
+					Default:    envValueDefault,
 				},
 			},
 			expected: &types.EnvVar{
-				Name:        "API_KEY",
-				Description: "API key",
+				Name:        envAPIKey,
+				Description: envDescAPIKey,
 				Required:    true,
 				Secret:      true,
-				Default:     "default-key",
+				Default:     envValueDefault,
 			},
 		},
 		{
 			name:        "variable reference without metadata",
-			value:       "TOKEN={token}",
-			description: "Auth token",
+			value:       envTokenTpl,
+			description: envDescAuthToken,
 			variables:   map[string]model.Input{},
 			expected: &types.EnvVar{
-				Name:        "TOKEN",
-				Description: "Auth token",
+				Name:        envToken,
+				Description: envDescAuthToken,
 			},
 		},
 		{
@@ -297,19 +297,19 @@ func TestExtractEnvironmentVariables(t *testing.T) {
 					{
 						InputWithVariables: model.InputWithVariables{
 							Input: model.Input{
-								Description: "API key",
+								Description: envDescAPIKey,
 								IsRequired:  true,
 								IsSecret:    true,
 							},
 						},
-						Name: "API_KEY",
+						Name: envAPIKey,
 					},
 				},
 			},
 			expected: []*types.EnvVar{
 				{
-					Name:        "API_KEY",
-					Description: "API key",
+					Name:        envAPIKey,
+					Description: envDescAPIKey,
 					Required:    true,
 					Secret:      true,
 				},
@@ -322,12 +322,12 @@ func TestExtractEnvironmentVariables(t *testing.T) {
 					{
 						InputWithVariables: model.InputWithVariables{
 							Input: model.Input{
-								Value:       "TOKEN={token}",
-								Description: "Auth token",
+								Value:       envTokenTpl,
+								Description: envDescAuthToken,
 								IsRequired:  true,
 							},
 							Variables: map[string]model.Input{
-								"token": {
+								valueToken: {
 									IsRequired: true,
 									IsSecret:   true,
 								},
@@ -340,8 +340,8 @@ func TestExtractEnvironmentVariables(t *testing.T) {
 			},
 			expected: []*types.EnvVar{
 				{
-					Name:        "TOKEN",
-					Description: "Auth token",
+					Name:        envToken,
+					Description: envDescAuthToken,
 					Required:    true,
 					Secret:      true,
 				},
@@ -432,7 +432,7 @@ func TestServerJSONToImageMetadata_GitHubServerEnvVars(t *testing.T) {
 		{
 			InputWithVariables: model.InputWithVariables{
 				Input: model.Input{
-					Value:       "true",
+					Value:       envValueTrue,
 					Description: "Run container in interactive mode",
 					IsRequired:  true,
 					Format:      "boolean",
@@ -445,11 +445,11 @@ func TestServerJSONToImageMetadata_GitHubServerEnvVars(t *testing.T) {
 			InputWithVariables: model.InputWithVariables{
 				Input: model.Input{
 					Value:       "GITHUB_PERSONAL_ACCESS_TOKEN={token}",
-					Description: "Set an environment variable in the runtime",
+					Description: envDescRuntime,
 					IsRequired:  true,
 				},
 				Variables: map[string]model.Input{
-					"token": {
+					valueToken: {
 						IsRequired: true,
 						IsSecret:   true,
 						Format:     "string",
@@ -468,7 +468,7 @@ func TestServerJSONToImageMetadata_GitHubServerEnvVars(t *testing.T) {
 	// Verify environment variable was extracted
 	require.Len(t, result.EnvVars, 1)
 	assert.Equal(t, "GITHUB_PERSONAL_ACCESS_TOKEN", result.EnvVars[0].Name)
-	assert.Equal(t, "Set an environment variable in the runtime", result.EnvVars[0].Description)
+	assert.Equal(t, envDescRuntime, result.EnvVars[0].Description)
 	assert.True(t, result.EnvVars[0].Required)
 	assert.True(t, result.EnvVars[0].Secret)
 }

--- a/registry/converters/registry_converters_test.go
+++ b/registry/converters/registry_converters_test.go
@@ -23,8 +23,8 @@ func TestNewUpstreamRegistryFromToolhiveRegistry(t *testing.T) {
 		{
 			name: "successful conversion with container servers",
 			toolhiveReg: &registry.Registry{
-				Version:     "1.0.0",
-				LastUpdated: "2024-01-01T00:00:00Z",
+				Version:     testVersion,
+				LastUpdated: testLastUpdated,
 				Servers: map[string]*registry.ImageMetadata{
 					"test-server": {
 						BaseServerMetadata: registry.BaseServerMetadata{
@@ -43,8 +43,8 @@ func TestNewUpstreamRegistryFromToolhiveRegistry(t *testing.T) {
 			expectError: false,
 			validate: func(t *testing.T, sr *registry.UpstreamRegistry) {
 				t.Helper()
-				assert.Equal(t, "1.0.0", sr.Version)
-				assert.Equal(t, "2024-01-01T00:00:00Z", sr.Meta.LastUpdated)
+				assert.Equal(t, testVersion, sr.Version)
+				assert.Equal(t, testLastUpdated, sr.Meta.LastUpdated)
 				assert.Len(t, sr.Data.Servers, 1)
 				assert.Contains(t, sr.Data.Servers[0].Name, "test-server")
 				assert.Equal(t, "A test server", sr.Data.Servers[0].Description)
@@ -53,8 +53,8 @@ func TestNewUpstreamRegistryFromToolhiveRegistry(t *testing.T) {
 		{
 			name: "successful conversion with remote servers",
 			toolhiveReg: &registry.Registry{
-				Version:     "1.0.0",
-				LastUpdated: "2024-01-01T00:00:00Z",
+				Version:     testVersion,
+				LastUpdated: testLastUpdated,
 				Servers:     make(map[string]*registry.ImageMetadata),
 				RemoteServers: map[string]*registry.RemoteServerMetadata{
 					"remote-server": {
@@ -63,7 +63,7 @@ func TestNewUpstreamRegistryFromToolhiveRegistry(t *testing.T) {
 							Description: "A remote server",
 							Tier:        "Community",
 							Status:      "Active",
-							Transport:   "sse",
+							Transport:   testTransportSSE,
 							Tools:       []string{"remote_tool"},
 						},
 						URL: "https://example.com",
@@ -80,8 +80,8 @@ func TestNewUpstreamRegistryFromToolhiveRegistry(t *testing.T) {
 		{
 			name: "empty registry",
 			toolhiveReg: &registry.Registry{
-				Version:       "1.0.0",
-				LastUpdated:   "2024-01-01T00:00:00Z",
+				Version:       testVersion,
+				LastUpdated:   testLastUpdated,
 				Servers:       make(map[string]*registry.ImageMetadata),
 				RemoteServers: make(map[string]*registry.RemoteServerMetadata),
 			},

--- a/registry/converters/testconst_test.go
+++ b/registry/converters/testconst_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package converters
+
+const (
+	testVersion     = "1.0.0"
+	testLastUpdated = "2024-01-01T00:00:00Z"
+
+	testImageRef          = "ghcr.io/test/server:latest"
+	testNamespace         = "io.github.stacklok"
+	testServerNameFetchFQ = "io.github.stacklok/fetch"
+	testServerNameFetch   = "fetch"
+
+	testName        = "test"
+	testTier        = "Official"
+	testToolName    = "tool1"
+	testToolNameAlt = "tool2"
+	testCategory    = "example"
+
+	testTransportSSE = "sse"
+	testRemoteURL    = "https://api.example.com/mcp"
+
+	tierKey  = "tier"
+	toolsKey = "tools"
+
+	envAPIKey       = "API_KEY"
+	envDebug        = "DEBUG"
+	envToken        = "TOKEN"
+	envValueDefault = "default-key"
+	envValueTrue    = "true"
+	envTokenTpl     = "TOKEN={token}"
+	valueToken      = "token"
+
+	envDescAPIKey    = "API key"
+	envDescAuthToken = "Auth token"
+	envDescRuntime   = "Set an environment variable in the runtime"
+)

--- a/registry/converters/toolhive_to_upstream.go
+++ b/registry/converters/toolhive_to_upstream.go
@@ -23,6 +23,13 @@ import (
 	registry "github.com/stacklok/toolhive-core/registry/types"
 )
 
+const (
+	defaultVersion   = "1.0.0"
+	repoSourceGitHub = "github"
+	defaultStatus    = "active"
+	statusKey        = "status"
+)
+
 // ImageMetadataToServerJSON converts toolhive ImageMetadata to an upstream ServerJSON
 // The name parameter is deprecated and should match imageMetadata.Name. It's kept for backward compatibility.
 func ImageMetadataToServerJSON(name string, imageMetadata *registry.ImageMetadata) (*upstream.ServerJSON, error) {
@@ -45,14 +52,14 @@ func ImageMetadataToServerJSON(name string, imageMetadata *registry.ImageMetadat
 		Name:        canonicalName,
 		Title:       imageMetadata.Title,
 		Description: imageMetadata.Description,
-		Version:     "1.0.0", // TODO: Extract from image tag or metadata
+		Version:     defaultVersion, // TODO: Extract from image tag or metadata
 	}
 
 	// Set repository if available
 	if imageMetadata.RepositoryURL != "" {
 		serverJSON.Repository = &model.Repository{
 			URL:    imageMetadata.RepositoryURL,
-			Source: "github", // Assume GitHub
+			Source: repoSourceGitHub, // Assume GitHub
 		}
 	}
 
@@ -89,14 +96,14 @@ func RemoteServerMetadataToServerJSON(name string, remoteMetadata *registry.Remo
 		Name:        canonicalName,
 		Title:       remoteMetadata.Title,
 		Description: remoteMetadata.Description,
-		Version:     "1.0.0", // TODO: Version management
+		Version:     defaultVersion, // TODO: Version management
 	}
 
 	// Set repository if available
 	if remoteMetadata.RepositoryURL != "" {
 		serverJSON.Repository = &model.Repository{
 			URL:    remoteMetadata.RepositoryURL,
-			Source: "github", // Assume GitHub
+			Source: repoSourceGitHub, // Assume GitHub
 		}
 	}
 
@@ -191,7 +198,7 @@ func createRemotesFromRemoteMetadata(remoteMetadata *registry.RemoteServerMetada
 // map structure, defaulting Status to "active" if empty.
 func buildPublisherExtensionsMap(ext registry.ServerExtensions, innerKey string) map[string]interface{} {
 	if ext.Status == "" {
-		ext.Status = "active"
+		ext.Status = defaultStatus
 	}
 	return map[string]interface{}{
 		registry.ToolHivePublisherNamespace: map[string]interface{}{
@@ -247,12 +254,12 @@ func serverExtensionsToMap(ext registry.ServerExtensions) map[string]interface{}
 	data, err := json.Marshal(ext)
 	if err != nil {
 		// Fallback: return a minimal map with just the status
-		return map[string]interface{}{"status": ext.Status}
+		return map[string]interface{}{statusKey: ext.Status}
 	}
 
 	var result map[string]interface{}
 	if err := json.Unmarshal(data, &result); err != nil {
-		return map[string]interface{}{"status": ext.Status}
+		return map[string]interface{}{statusKey: ext.Status}
 	}
 
 	return result

--- a/registry/types/registry_types_test.go
+++ b/registry/types/registry_types_test.go
@@ -159,8 +159,8 @@ func TestRegistry_GetServerByName(t *testing.T) {
 		remote   bool
 		found    bool
 	}{
-		{"server-a", "server-a", false, true},
-		{"remote-a", "remote-a", true, true},
+		{testServerName, testServerName, false, true},
+		{testRemoteName, testRemoteName, true, true},
 		{"missing", "", false, false},
 	}
 	for _, tc := range tests {

--- a/registry/types/schema_validation_test.go
+++ b/registry/types/schema_validation_test.go
@@ -60,7 +60,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				"servers": {}
 			}`,
 			expectError:   true,
-			errorContains: "version",
+			errorContains: errKeyVersion,
 		},
 		{
 			name: "missing required last_updated field",
@@ -69,7 +69,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				"servers": {}
 			}`,
 			expectError:   true,
-			errorContains: "last_updated",
+			errorContains: errKeyLastUpdated,
 		},
 		{
 			name: "missing required servers field",
@@ -88,7 +88,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				"servers": {}
 			}`,
 			expectError:   true,
-			errorContains: "version",
+			errorContains: errKeyVersion,
 		},
 		{
 			name: "invalid date format",
@@ -98,7 +98,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				"servers": {}
 			}`,
 			expectError:   true,
-			errorContains: "last_updated",
+			errorContains: errKeyLastUpdated,
 		},
 		{
 			name: "server missing required description",
@@ -116,7 +116,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				}
 			}`,
 			expectError:   true,
-			errorContains: "description",
+			errorContains: errKeyDescription,
 		},
 		{
 			name: "server missing required image",
@@ -153,7 +153,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				}
 			}`,
 			expectError:   true,
-			errorContains: "status",
+			errorContains: errKeyStatus,
 		},
 		{
 			name: "server with invalid tier",
@@ -172,7 +172,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				}
 			}`,
 			expectError:   true,
-			errorContains: "tier",
+			errorContains: errKeyTier,
 		},
 		{
 			name: "server with invalid transport",
@@ -229,7 +229,7 @@ func TestRegistrySchemaValidation(t *testing.T) {
 				}
 			}`,
 			expectError:   true,
-			errorContains: "description",
+			errorContains: errKeyDescription,
 		},
 		{
 			name: "non-matching server name passes without additionalProperties restriction",
@@ -356,10 +356,10 @@ func TestMultipleValidationErrors(t *testing.T) {
 	assert.Contains(t, errorMsg, "validation failed with", "Should indicate multiple errors")
 
 	// Should contain specific error details
-	assert.Contains(t, errorMsg, "version", "Should mention missing version")
-	assert.Contains(t, errorMsg, "last_updated", "Should mention missing last_updated")
-	assert.Contains(t, errorMsg, "description", "Should mention description length issue")
-	assert.Contains(t, errorMsg, "status", "Should mention invalid status")
+	assert.Contains(t, errorMsg, errKeyVersion, "Should mention missing version")
+	assert.Contains(t, errorMsg, errKeyLastUpdated, "Should mention missing last_updated")
+	assert.Contains(t, errorMsg, errKeyDescription, "Should mention description length issue")
+	assert.Contains(t, errorMsg, errKeyStatus, "Should mention invalid status")
 	assert.Contains(t, errorMsg, "tools", "Should mention empty tools array")
 
 	// Verify it's formatted as a numbered list
@@ -473,7 +473,7 @@ func TestValidateUpstreamRegistryBytes(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "last_updated",
+			errorContains: errKeyLastUpdated,
 		},
 		{
 			name: "invalid version format",
@@ -487,7 +487,7 @@ func TestValidateUpstreamRegistryBytes(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "version",
+			errorContains: errKeyVersion,
 		},
 		{
 			name: "invalid date format",
@@ -520,7 +520,7 @@ func TestValidateUpstreamRegistryBytes(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "description",
+			errorContains: errKeyDescription,
 		},
 	}
 
@@ -726,7 +726,7 @@ func TestValidatePublisherProvidedExtensionsBytes(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "status",
+			errorContains: errKeyStatus,
 		},
 		{
 			name: "invalid status value",
@@ -738,7 +738,7 @@ func TestValidatePublisherProvidedExtensionsBytes(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "status",
+			errorContains: errKeyStatus,
 		},
 		{
 			name: "invalid tier value",
@@ -751,7 +751,7 @@ func TestValidatePublisherProvidedExtensionsBytes(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "tier",
+			errorContains: errKeyTier,
 		},
 		{
 			name: "invalid proxy_port (too high)",
@@ -1057,7 +1057,7 @@ func TestValidateUpstreamRegistry_WithExtensions(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "status",
+			errorContains: errKeyStatus,
 		},
 		{
 			name: "invalid extensions - invalid tier value",
@@ -1087,7 +1087,7 @@ func TestValidateUpstreamRegistry_WithExtensions(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "tier",
+			errorContains: errKeyTier,
 		},
 		{
 			name: "valid registry with extensions in groups",
@@ -1158,7 +1158,7 @@ func TestValidateUpstreamRegistry_WithExtensions(t *testing.T) {
 				}
 			}`,
 			wantErr:       true,
-			errorContains: "status",
+			errorContains: errKeyStatus,
 		},
 	}
 
@@ -1448,7 +1448,7 @@ func TestValidateSkillBytes(t *testing.T) {
 				"version": "1.0.0"
 			}`,
 			wantErr:       true,
-			errorContains: "description",
+			errorContains: errKeyDescription,
 		},
 		{
 			name: "missing required version",
@@ -1458,7 +1458,7 @@ func TestValidateSkillBytes(t *testing.T) {
 				"description": "Extract text and tables"
 			}`,
 			wantErr:       true,
-			errorContains: "version",
+			errorContains: errKeyVersion,
 		},
 		{
 			name: "invalid status value",
@@ -1470,7 +1470,7 @@ func TestValidateSkillBytes(t *testing.T) {
 				"status": "invalid-status"
 			}`,
 			wantErr:       true,
-			errorContains: "status",
+			errorContains: errKeyStatus,
 		},
 		{
 			name: "invalid package registryType",
@@ -1518,7 +1518,7 @@ func TestRegistry_Validate(t *testing.T) {
 		{
 			name: "valid minimal registry",
 			registry: &Registry{
-				Version:     "1.0.0",
+				Version:     testVersion,
 				LastUpdated: "2025-01-01T00:00:00Z",
 				Servers:     map[string]*ImageMetadata{},
 			},
@@ -1557,7 +1557,7 @@ func TestUpstreamRegistry_Validate(t *testing.T) {
 			name: "valid minimal upstream registry",
 			registry: &UpstreamRegistry{
 				Schema:  UpstreamRegistrySchemaURL,
-				Version: "1.0.0",
+				Version: testVersion,
 				Meta: UpstreamMeta{
 					LastUpdated: "2025-01-01T00:00:00Z",
 				},
@@ -1636,7 +1636,7 @@ func TestSkill_Validate(t *testing.T) {
 				Namespace:   "io.github.example",
 				Name:        "my-skill",
 				Description: "A test skill for validation",
-				Version:     "1.0.0",
+				Version:     testVersion,
 			},
 			expectError: false,
 		},
@@ -1651,7 +1651,7 @@ func TestSkill_Validate(t *testing.T) {
 				Namespace:   "io.github.example",
 				Name:        "my-skill",
 				Description: "A test skill for validation",
-				Version:     "1.0.0",
+				Version:     testVersion,
 				Status:      "invalid-status",
 			},
 			expectError: true,

--- a/registry/types/test_constants_test.go
+++ b/registry/types/test_constants_test.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+const (
+	testVersion       = "1.0.0"
+	testServerName    = "server-a"
+	testRemoteName    = "remote-a"
+	errKeyVersion     = "version"
+	errKeyLastUpdated = "last_updated"
+	errKeyDescription = "description"
+	errKeyStatus      = "status"
+	errKeyTier        = "tier"
+)

--- a/registry/types/upstream_registry_test.go
+++ b/registry/types/upstream_registry_test.go
@@ -18,7 +18,7 @@ func TestUpstreamRegistry_JSONSerialization(t *testing.T) {
 	t.Parallel()
 	registry := &UpstreamRegistry{
 		Schema:  UpstreamRegistrySchemaURL,
-		Version: "1.0.0",
+		Version: testVersion,
 		Meta: UpstreamMeta{
 			LastUpdated: time.Now().Format(time.RFC3339),
 		},
@@ -48,7 +48,7 @@ func TestUpstreamRegistry_YAMLSerialization(t *testing.T) {
 	t.Parallel()
 	registry := &UpstreamRegistry{
 		Schema:  UpstreamRegistrySchemaURL,
-		Version: "1.0.0",
+		Version: testVersion,
 		Meta: UpstreamMeta{
 			LastUpdated: "2024-01-15T10:30:00Z",
 		},
@@ -76,7 +76,7 @@ func TestUpstreamRegistry_WithGroups(t *testing.T) {
 	t.Parallel()
 	registry := &UpstreamRegistry{
 		Schema:  UpstreamRegistrySchemaURL,
-		Version: "1.0.0",
+		Version: testVersion,
 		Meta: UpstreamMeta{
 			LastUpdated: time.Now().Format(time.RFC3339),
 		},
@@ -107,7 +107,7 @@ func TestUpstreamRegistry_SchemaField(t *testing.T) {
 
 	registry := &UpstreamRegistry{
 		Schema:  UpstreamRegistrySchemaURL,
-		Version: "1.0.0",
+		Version: testVersion,
 		Meta: UpstreamMeta{
 			LastUpdated: time.Now().Format(time.RFC3339),
 		},
@@ -182,7 +182,7 @@ func TestUpstreamRegistry_WithSkills(t *testing.T) {
 	t.Parallel()
 	reg := &UpstreamRegistry{
 		Schema:  UpstreamRegistrySchemaURL,
-		Version: "1.0.0",
+		Version: testVersion,
 		Meta: UpstreamMeta{
 			LastUpdated: time.Now().Format(time.RFC3339),
 		},
@@ -193,7 +193,7 @@ func TestUpstreamRegistry_WithSkills(t *testing.T) {
 					Namespace:   "io.github.stacklok",
 					Name:        "pdf-processor",
 					Description: "Extract text and tables from PDF files",
-					Version:     "1.0.0",
+					Version:     testVersion,
 					Status:      "active",
 					Packages: []SkillPackage{
 						{
@@ -215,7 +215,7 @@ func TestUpstreamRegistry_WithSkills(t *testing.T) {
 	require.Len(t, decoded.Data.Skills, 1)
 	assert.Equal(t, "io.github.stacklok", decoded.Data.Skills[0].Namespace)
 	assert.Equal(t, "pdf-processor", decoded.Data.Skills[0].Name)
-	assert.Equal(t, "1.0.0", decoded.Data.Skills[0].Version)
+	assert.Equal(t, testVersion, decoded.Data.Skills[0].Version)
 	require.Len(t, decoded.Data.Skills[0].Packages, 1)
 	assert.Equal(t, "oci", decoded.Data.Skills[0].Packages[0].RegistryType)
 }
@@ -230,7 +230,7 @@ func TestRegistryGroup_Structure(t *testing.T) {
 			{
 				Name:        "io.test/server1",
 				Description: "Test server 1",
-				Version:     "1.0.0",
+				Version:     testVersion,
 			},
 		},
 	}

--- a/validation/http/http_test.go
+++ b/validation/http/http_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const tcEmptyString = "empty string"
+
 func TestValidateHeaderName(t *testing.T) {
 	t.Parallel()
 
@@ -33,7 +35,7 @@ func TestValidateHeaderName(t *testing.T) {
 		// Other invalid characters
 		{"null byte", "X-API-Key\x00", true},
 		{"contains space", "X API Key", true},
-		{"empty string", "", true},
+		{tcEmptyString, "", true},
 
 		// Length limits
 		{"too long", strings.Repeat("A", 300), true},
@@ -78,7 +80,7 @@ func TestValidateHeaderValue(t *testing.T) {
 
 		// Length limits
 		{"too long", strings.Repeat("A", 10000), true},
-		{"empty string", "", true},
+		{tcEmptyString, "", true},
 	}
 
 	for _, tt := range tests {
@@ -136,7 +138,7 @@ func TestValidateResourceURI(t *testing.T) {
 		},
 		// Invalid cases
 		{
-			name:          "empty string",
+			name:          tcEmptyString,
 			input:         "",
 			expectError:   true,
 			errorContains: "cannot be empty",


### PR DESCRIPTION
## Summary

- The latest `golangci-lint` (v2.12.x) detects more repeated string literals in the `goconst` linter, surfacing **95 new issues** across the codebase. This was visible on PR #96 (a Renovate dependency bump) where lint failed despite no code changes from the PR.
- Extract repeated literals into named constants — production code uses package-level constants (some exported where semantically meaningful, e.g. `MediaTypeOCIEmptyV1JSON`, `ArchAMD64`, `SkillFileName`), test files use unexported package-level test constants.
- No behavior changes. `task lint` is clean and the full test suite passes.

## Affected packages

| Package | Issues fixed | Notes |
|---|---|---|
| `cel` | 10 | Test-only constants for CEL expressions and claim names |
| `container/verifier` | 5 | Hoisted OCI/Sigstore media types into `utils.go` |
| `oci/skills` | 23 | Exported `OSLinux`, `ArchAMD64`, `ArchARM64`, `SkillFileName`; added `testconsts_test.go` |
| `permissions` | 13 | Test-only constants for paths and mount declarations |
| `registry/converters` | 34 | Production constants in `toolhive_to_upstream.go`; added `testconst_test.go` |
| `registry/types` | 9 | Added `test_constants_test.go` |
| `validation/http` | 1 | Single test-case-name constant |

## Test plan

- [x] `task lint` passes with 0 issues
- [x] `task test` passes (all packages green)
- [x] `task license-check` passes for the new files
- [x] No public API changes that would break downstream consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)