### PR TITLE
audit: export `LevelAudit` slog level constant

### DIFF
--- a/audit/event.go
+++ b/audit/event.go
@@ -145,6 +145,14 @@ func (e *AuditEvent) WithDataFromString(data string) *AuditEvent {
 	return e.WithData(&rawMsg)
 }
 
+// LevelAudit is a custom slog level for audit events, sitting between
+// [slog.LevelInfo] (0) and [slog.LevelWarn] (4). Logging audit events at this
+// dedicated level lets log infrastructure filter them independently from
+// regular application logs. Pass it as the level argument to [AuditEvent.LogTo]
+// and as the Level in a handler's [slog.HandlerOptions] so all ToolHive
+// components share one definition rather than hardcoding the numeric value.
+const LevelAudit = slog.Level(2)
+
 // LogTo logs the audit event to the provided slog.Logger using the custom audit level.
 func (e *AuditEvent) LogTo(ctx context.Context, logger *slog.Logger, level slog.Level) {
 	// Create slog attributes for the audit event

--- a/audit/event_test.go
+++ b/audit/event_test.go
@@ -184,6 +184,16 @@ func TestConstants(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, "toolhive-api", ComponentToolHive)
 	})
+
+	t.Run("audit level", func(t *testing.T) {
+		t.Parallel()
+		// Value must stay between Info and Warn so audit events can be
+		// filtered independently. Changing it is a breaking change for
+		// consumers that hardcode the numeric level.
+		assert.Equal(t, slog.Level(2), LevelAudit)
+		assert.Greater(t, LevelAudit, slog.LevelInfo)
+		assert.Less(t, LevelAudit, slog.LevelWarn)
+	})
 }
 
 func TestEventMetadataExtra(t *testing.T) {
@@ -249,8 +259,7 @@ func TestAuditEventLogTo(t *testing.T) {
 		"transport":   "sse",
 	}
 
-	customLevel := slog.Level(2)
-	event.LogTo(context.Background(), logger, customLevel)
+	event.LogTo(context.Background(), logger, LevelAudit)
 
 	logOutput := buf.String()
 	require.NotEmpty(t, logOutput)


### PR DESCRIPTION
## Summary

Adds an exported `LevelAudit = slog.Level(2)` constant to the `audit` package so all ToolHive components share a single definition of the custom audit log level instead of each hardcoding the numeric value.

Today both the toolhive operator (`pkg/audit/auditor.go`) and the registry server (`internal/audit/logger.go`) define `slog.Level(2)` independently. Exporting it here lets them converge on one source of truth.

The level sits between `slog.LevelInfo` (0) and `slog.LevelWarn` (4) so audit events can be filtered independently from regular application logs.

## Changes

- `audit/event.go`: export `const LevelAudit = slog.Level(2)` with doc comment
- `audit/event_test.go`: add a `TestConstants` subtest locking the value and its ordering (`Info < LevelAudit < Warn`), since changing it would break consumers that filter on the numeric level; use the constant in `TestAuditEventLogTo`

## Context

Enables stacklok/toolhive-registry-server#826 — the registry server will import `audit.LevelAudit` rather than redefining it locally, and render the level as `"AUDIT"` to match the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)