### PR TITLE
refactor(registry/types): swap mcp-go import for mcpcompat shim

### DIFF
--- a/registry/types/publisher_provided_types.go
+++ b/registry/types/publisher_provided_types.go
@@ -4,8 +4,7 @@
 package registry
 
 import (
-	"github.com/mark3labs/mcp-go/mcp"
-
+	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	"github.com/stacklok/toolhive-core/permissions"
 )
 

--- a/registry/types/registry_types.go
+++ b/registry/types/registry_types.go
@@ -8,9 +8,9 @@ import (
 	"slices"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
 	"gopkg.in/yaml.v3"
 
+	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
 	"github.com/stacklok/toolhive-core/permissions"
 )
 


### PR DESCRIPTION
## Summary

Stop `registry/types` from importing `github.com/mark3labs/mcp-go/mcp` directly. Switch both files that reference it to import the `mcpcompat/mcp` shim (aliased as `mcp`), whose `Tool` type is a type alias for `mcpgo.Tool` — identical type, wire-compatible, source-compatible. This was the last non-shim import of mcp-go in the module.

Unblocks stacklok/toolhive#5729 from carrying mcp-go as a transitive indirect dep.

## What changed

Two import-path swaps, zero call-site logic changes:

- **`registry/types/publisher_provided_types.go`** — `"github.com/mark3labs/mcp-go/mcp"` → `mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"` (sole usage: `ToolDefinitions []mcp.Tool`).
- **`registry/types/registry_types.go`** — same swap (usages: `ToolDefinitions []mcp.Tool`, the `GetToolDefinitions() []mcp.Tool` interface method, and its `BaseServerMetadata` implementation).

Because `mcpcompat/mcp.Tool` is a type alias for `mcpgo.Tool`, all struct tags, JSON marshaling, and the `swaggerignore:"true"` tag remain identical. The `gci` linter regrouped the imports so the shim now sits with the other `stacklok/toolhive-core` imports rather than the third-party block.

## What did NOT change

- `mcpcompat/mcp/alias.go` is untouched — it remains the single intentional chokepoint that references mcp-go (per its own `doc.go`).
- `go.mod`/`go.sum` unchanged — `go mod tidy` made no change. mcp-go stays as a direct dep because the `mcpcompat/mcp` shim still references it. That's expected and acceptable per the task: the goal is to remove the **non-shim** import, not the shim itself.
- No test files in `registry/types` imported mcp-go directly, so none needed swapping.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./registry/types/... ./mcpcompat/...` — passes (the wire-format golden tests in mcpcompat pin the JSON shape; unaffected since the type is unchanged)
- `task` (lint + test) — green, 0 lint issues
- Invariant holds: `grep -rln "github.com/mark3labs/mcp-go" --include="*.go" . | grep -v "_test.go" | grep -v "mcpcompat/"` returns nothing.