### PR TITLE
Fix mcpcompat dropping results that embed a resource

### DIFF
--- a/mcpcompat/mcp/content.go
+++ b/mcpcompat/mcp/content.go
@@ -122,6 +122,56 @@ type EmbeddedResource struct {
 
 func (EmbeddedResource) isContent() {}
 
+// embeddedResourceJSON is a helper for unmarshaling EmbeddedResource, whose
+// Resource field is the ResourceContents interface and cannot be populated by
+// a generic JSON round-trip.
+type embeddedResourceJSON struct {
+	Annotated
+	Meta     *Meta           `json:"_meta,omitempty"`
+	Type     string          `json:"type"`
+	Resource json.RawMessage `json:"resource"`
+}
+
+// UnmarshalJSON decodes an embedded resource, resolving the polymorphic
+// Resource field to a concrete TextResourceContents or BlobResourceContents.
+// Without this, stdlib cannot unmarshal into the ResourceContents interface and
+// any "type":"resource" content item errors, aborting the whole result decode.
+func (e *EmbeddedResource) UnmarshalJSON(data []byte) error {
+	var raw embeddedResourceJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	e.Annotated = raw.Annotated
+	e.Meta = raw.Meta
+	e.Type = raw.Type
+
+	if len(raw.Resource) == 0 {
+		return nil
+	}
+	// Peek to decide text vs blob. A non-empty "blob" field means blob contents;
+	// otherwise treat as text (mirrors the client's convertReadResourceResult).
+	var probe struct {
+		Blob string `json:"blob"`
+	}
+	if err := json.Unmarshal(raw.Resource, &probe); err != nil {
+		return err
+	}
+	if probe.Blob != "" {
+		var blob BlobResourceContents
+		if err := json.Unmarshal(raw.Resource, &blob); err != nil {
+			return err
+		}
+		e.Resource = blob
+		return nil
+	}
+	var text TextResourceContents
+	if err := json.Unmarshal(raw.Resource, &text); err != nil {
+		return err
+	}
+	e.Resource = text
+	return nil
+}
+
 // ToolUseContent represents a request from the assistant to call a tool within a sampling message.
 // It must have Type set to "tool_use".
 type ToolUseContent struct {

--- a/mcpcompat/mcp/embedded_resource_test.go
+++ b/mcpcompat/mcp/embedded_resource_test.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
+)
+
+// TestUnmarshalContent_EmbeddedResource covers the chokepoint used by both
+// tools/call and prompts/get: a "type":"resource" content item must decode into
+// an EmbeddedResource whose polymorphic Resource field resolves to the correct
+// concrete text/blob type. Before the custom UnmarshalJSON this errored,
+// aborting the whole result decode.
+func TestUnmarshalContent_EmbeddedResource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text resource", func(t *testing.T) {
+		t.Parallel()
+		wire := []byte(`{"type":"resource","resource":{"uri":"file:///x.txt","mimeType":"text/plain","text":"embedded body"}}`)
+
+		c, err := mcp.UnmarshalContent(wire)
+		require.NoError(t, err)
+
+		er, ok := c.(mcp.EmbeddedResource)
+		require.True(t, ok, "expected EmbeddedResource, got %T", c)
+		trc, ok := er.Resource.(mcp.TextResourceContents)
+		require.True(t, ok, "expected TextResourceContents, got %T", er.Resource)
+		assert.Equal(t, "file:///x.txt", trc.URI)
+		assert.Equal(t, "text/plain", trc.MIMEType)
+		assert.Equal(t, "embedded body", trc.Text)
+	})
+
+	t.Run("blob resource", func(t *testing.T) {
+		t.Parallel()
+		wire := []byte(`{"type":"resource","resource":{"uri":"file:///x.png","mimeType":"image/png","blob":"UE5HREFUQQ=="}}`)
+
+		c, err := mcp.UnmarshalContent(wire)
+		require.NoError(t, err)
+
+		er, ok := c.(mcp.EmbeddedResource)
+		require.True(t, ok, "expected EmbeddedResource, got %T", c)
+		brc, ok := er.Resource.(mcp.BlobResourceContents)
+		require.True(t, ok, "expected BlobResourceContents, got %T", er.Resource)
+		assert.Equal(t, "file:///x.png", brc.URI)
+		assert.Equal(t, "image/png", brc.MIMEType)
+		assert.Equal(t, "UE5HREFUQQ==", brc.Blob)
+	})
+}
+
+// TestCallToolResult_MixedContent asserts that a single embedded resource no
+// longer aborts the decode of sibling text/image parts.
+func TestCallToolResult_MixedContent(t *testing.T) {
+	t.Parallel()
+
+	wire := []byte(`{"content":[` +
+		`{"type":"text","text":"hello"},` +
+		`{"type":"image","data":"UE5HREFUQQ==","mimeType":"image/png"},` +
+		`{"type":"resource","resource":{"uri":"file:///x.txt","mimeType":"text/plain","text":"body"}}` +
+		`]}`)
+
+	var r mcp.CallToolResult
+	require.NoError(t, json.Unmarshal(wire, &r))
+	require.Len(t, r.Content, 3)
+
+	txt, ok := r.Content[0].(mcp.TextContent)
+	require.True(t, ok, "content[0] should be TextContent, got %T", r.Content[0])
+	assert.Equal(t, "hello", txt.Text)
+
+	img, ok := r.Content[1].(mcp.ImageContent)
+	require.True(t, ok, "content[1] should be ImageContent, got %T", r.Content[1])
+	assert.Equal(t, "image/png", img.MIMEType)
+
+	er, ok := r.Content[2].(mcp.EmbeddedResource)
+	require.True(t, ok, "content[2] should be EmbeddedResource, got %T", r.Content[2])
+	trc, ok := er.Resource.(mcp.TextResourceContents)
+	require.True(t, ok, "expected TextResourceContents, got %T", er.Resource)
+	assert.Equal(t, "body", trc.Text)
+}
+
+// TestEmbeddedResource_RoundTrip decodes, re-marshals, and decodes again,
+// asserting the concrete type and fields are stable across the round trip.
+func TestEmbeddedResource_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		wire string
+	}{
+		{
+			name: "text",
+			wire: `{"type":"resource","resource":{"uri":"file:///x.txt","mimeType":"text/plain","text":"body"}}`,
+		},
+		{
+			name: "blob",
+			wire: `{"type":"resource","resource":{"uri":"file:///x.png","mimeType":"image/png","blob":"UE5HREFUQQ=="}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			first, err := mcp.UnmarshalContent([]byte(tt.wire))
+			require.NoError(t, err)
+
+			remarshaled, err := mcp.MarshalContent(first)
+			require.NoError(t, err)
+
+			second, err := mcp.UnmarshalContent(remarshaled)
+			require.NoError(t, err)
+
+			assert.Equal(t, first, second)
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a custom `UnmarshalJSON` to `mcpcompat.EmbeddedResource` so a `"type":"resource"` content item decodes correctly instead of erroring.

## Why

`EmbeddedResource.Resource` is the `ResourceContents` **interface** with no custom unmarshaler, so `json.Unmarshal` of any embedded-resource content item failed:

```
json: cannot unmarshal object into Go struct field EmbeddedResource.resource of type mcp.ResourceContents
```

That error propagated out of `CallToolResult.UnmarshalJSON` / the client's `convertResult`, discarding the **entire** result — so a tool result (or prompt message) containing an embedded resource lost all of its content, including sibling text/image parts.

`ReadResource`/`GetPrompt` were hand-written to sidestep this; `CallTool` was on the generic round-trip path. The new `UnmarshalJSON` lives at `UnmarshalContent`, the single chokepoint backing both `tools/call` and `prompts/get`, so one method fixes both.

## How

Resolve the polymorphic `Resource` field to a concrete `TextResourceContents`/`BlobResourceContents`, using blob-precedence to mirror the client's existing `convertReadResourceResult`.

## Tests

- `UnmarshalContent` decodes text and blob embedded resources to the right concrete type.
- `CallToolResult` mixed content `[text, image, resource]` — all three survive.
- Round-trip fidelity (decode → marshal → decode).

`task` passes (test + lint + vet), license headers verified.

Fixes #170