### PR TITLE
Fix EmbeddedResource JSON unmarshaling

### DIFF
--- a/mcpcompat/mcp/content.go
+++ b/mcpcompat/mcp/content.go
@@ -122,6 +122,70 @@ type EmbeddedResource struct {
 
 func (EmbeddedResource) isContent() {}
 
+// embeddedResourceJSON is a helper type for unmarshaling EmbeddedResource. It
+// mirrors EmbeddedResource but keeps the resource as a raw message so the
+// ResourceContents interface field can be decoded into a concrete type.
+type embeddedResourceJSON struct {
+	Annotated
+	Meta     *Meta           `json:"_meta,omitempty"`
+	Type     string          `json:"type"`
+	Resource json.RawMessage `json:"resource"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for EmbeddedResource.
+// The Resource field is a ResourceContents interface, which encoding/json
+// cannot populate directly. The nested resource object is decoded into the
+// concrete TextResourceContents or BlobResourceContents type based on the
+// presence of the "blob" (blob resource) or "text" (text resource) field,
+// mirroring the text/blob selection used elsewhere in the shim.
+func (er *EmbeddedResource) UnmarshalJSON(data []byte) error {
+	var raw embeddedResourceJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	er.Annotated = raw.Annotated
+	er.Meta = raw.Meta
+	er.Type = raw.Type
+
+	// An absent or JSON-null resource leaves Resource nil.
+	if len(raw.Resource) == 0 || string(raw.Resource) == "null" {
+		er.Resource = nil
+		return nil
+	}
+
+	resource, err := unmarshalResourceContents(raw.Resource)
+	if err != nil {
+		return fmt.Errorf("unmarshaling embedded resource contents: %w", err)
+	}
+	er.Resource = resource
+	return nil
+}
+
+// unmarshalResourceContents decodes a single JSON resource-contents object into
+// the concrete ResourceContents implementation. A blob resource carries a
+// "blob" field; a text resource carries "text". This mirrors the text/blob
+// selection performed by the client shim's convertReadResourceResult.
+func unmarshalResourceContents(data []byte) (ResourceContents, error) {
+	var probe struct {
+		Blob *string `json:"blob"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, err
+	}
+	if probe.Blob != nil {
+		var blob BlobResourceContents
+		if err := json.Unmarshal(data, &blob); err != nil {
+			return nil, err
+		}
+		return blob, nil
+	}
+	var text TextResourceContents
+	if err := json.Unmarshal(data, &text); err != nil {
+		return nil, err
+	}
+	return text, nil
+}
+
 // ToolUseContent represents a request from the assistant to call a tool within a sampling message.
 // It must have Type set to "tool_use".
 type ToolUseContent struct {

--- a/mcpcompat/mcp/content_test.go
+++ b/mcpcompat/mcp/content_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
+)
+
+// TestUnmarshalContent_EmbeddedResource_Text verifies that a "resource" content
+// carrying a text resource decodes into an EmbeddedResource whose Resource is a
+// TextResourceContents with all fields intact. Without EmbeddedResource's
+// custom UnmarshalJSON, encoding/json cannot populate the ResourceContents
+// interface field and this fails.
+func TestUnmarshalContent_EmbeddedResource_Text(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+		"type": "resource",
+		"resource": {
+			"uri": "file:///a.txt",
+			"mimeType": "text/plain",
+			"text": "hello world"
+		}
+	}`)
+
+	content, err := mcp.UnmarshalContent(data)
+	require.NoError(t, err)
+
+	er, ok := mcp.AsEmbeddedResource(content)
+	require.True(t, ok, "expected EmbeddedResource, got %T", content)
+	assert.Equal(t, mcp.ContentTypeResource, er.Type)
+
+	text, ok := mcp.AsTextResourceContents(er.Resource)
+	require.True(t, ok, "expected TextResourceContents, got %T", er.Resource)
+	assert.Equal(t, "file:///a.txt", text.URI)
+	assert.Equal(t, "text/plain", text.MIMEType)
+	assert.Equal(t, "hello world", text.Text)
+}
+
+// TestUnmarshalContent_EmbeddedResource_Blob verifies that a "resource" content
+// carrying a blob resource decodes into an EmbeddedResource whose Resource is a
+// BlobResourceContents with all fields intact.
+func TestUnmarshalContent_EmbeddedResource_Blob(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+		"type": "resource",
+		"resource": {
+			"uri": "file:///b.bin",
+			"mimeType": "application/octet-stream",
+			"blob": "ZGF0YQ=="
+		}
+	}`)
+
+	content, err := mcp.UnmarshalContent(data)
+	require.NoError(t, err)
+
+	er, ok := mcp.AsEmbeddedResource(content)
+	require.True(t, ok, "expected EmbeddedResource, got %T", content)
+	assert.Equal(t, mcp.ContentTypeResource, er.Type)
+
+	blob, ok := mcp.AsBlobResourceContents(er.Resource)
+	require.True(t, ok, "expected BlobResourceContents, got %T", er.Resource)
+	assert.Equal(t, "file:///b.bin", blob.URI)
+	assert.Equal(t, "application/octet-stream", blob.MIMEType)
+	assert.Equal(t, "ZGF0YQ==", blob.Blob)
+}
+
+// TestUnmarshalContent_EmbeddedResource_Absent verifies that an absent or null
+// resource decodes gracefully to a nil Resource without panicking.
+func TestUnmarshalContent_EmbeddedResource_Absent(t *testing.T) {
+	t.Parallel()
+
+	for name, data := range map[string]string{
+		"missing": `{"type":"resource"}`,
+		"null":    `{"type":"resource","resource":null}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := mcp.UnmarshalContent([]byte(data))
+			require.NoError(t, err)
+
+			er, ok := mcp.AsEmbeddedResource(content)
+			require.True(t, ok, "expected EmbeddedResource, got %T", content)
+			assert.Nil(t, er.Resource)
+		})
+	}
+}
+
+// TestCallToolResult_Unmarshal_WithEmbeddedResource_And_Siblings reproduces the
+// exact downstream failure: a CallToolResult whose content mixes text, image,
+// and an embedded resource. All three items must survive the unmarshal with
+// their fields intact. Without EmbeddedResource.UnmarshalJSON the whole result
+// decode errors and every sibling is lost.
+func TestCallToolResult_Unmarshal_WithEmbeddedResource_And_Siblings(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+		"content": [
+			{"type": "text", "text": "some text"},
+			{"type": "image", "data": "ZGF0YQ==", "mimeType": "image/png"},
+			{
+				"type": "resource",
+				"resource": {
+					"uri": "file:///embedded.txt",
+					"mimeType": "text/plain",
+					"text": "embedded body"
+				}
+			}
+		]
+	}`)
+
+	var result mcp.CallToolResult
+	err := json.Unmarshal(data, &result)
+	require.NoError(t, err)
+	require.Len(t, result.Content, 3, "all three content items must survive")
+
+	text, ok := mcp.AsTextContent(result.Content[0])
+	require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+	assert.Equal(t, "some text", text.Text)
+
+	img, ok := mcp.AsImageContent(result.Content[1])
+	require.True(t, ok, "expected ImageContent, got %T", result.Content[1])
+	assert.Equal(t, "ZGF0YQ==", img.Data)
+	assert.Equal(t, "image/png", img.MIMEType)
+
+	er, ok := mcp.AsEmbeddedResource(result.Content[2])
+	require.True(t, ok, "expected EmbeddedResource, got %T", result.Content[2])
+	embedded, ok := mcp.AsTextResourceContents(er.Resource)
+	require.True(t, ok, "expected TextResourceContents, got %T", er.Resource)
+	assert.Equal(t, "file:///embedded.txt", embedded.URI)
+	assert.Equal(t, "text/plain", embedded.MIMEType)
+	assert.Equal(t, "embedded body", embedded.Text)
+}


### PR DESCRIPTION
## Summary

- **Why:** `EmbeddedResource.Resource` is an interface-typed field (`ResourceContents`) with no custom `UnmarshalJSON`. `UnmarshalContent`'s `json.Unmarshal` into a plain `EmbeddedResource` therefore errored on **every** embedded-resource content item — `cannot unmarshal object into Go struct field EmbeddedResource.resource of type mcp.ResourceContents`. That aborted the entire `CallToolResult` / `GetPromptResult` decode, so a downstream consumer (ToolHive vMCP) dropped the **whole** result — including sibling text/image content — whenever a tool or prompt returned an embedded resource. Verified end-to-end: `client.CallTool` against a live go-sdk server hard-errors on the resource item.
- **What:** add `EmbeddedResource.UnmarshalJSON`, decoding the `resource` object into `TextResourceContents` or `BlobResourceContents` (by presence of `blob` vs `text`), mirroring the existing interface-decoding shims for `ReadResourceResult` and `PromptMessage` content. Fixes both the tool-call and prompt embedded-resource paths in one place.

Found by pointing the MCP conformance suite at a vMCP endpoint (`tools-call-embedded-resource` and `tools-call-mixed-content` failed).

## Test plan

- [x] `TestUnmarshalContent_EmbeddedResource_Text` / `_Blob` / `_Absent` — the resource object decodes into the right concrete type with fields intact (URI/MIMEType/Text or Blob), and the empty case doesn't panic.
- [x] `TestCallToolResult_Unmarshal_WithEmbeddedResource_And_Siblings` — a result with `[text, image, embedded-resource]` round-trips with **all three** items surviving (the exact downstream mixed-content failure).
- [x] Mutation-verified: without the new `UnmarshalJSON`, the siblings test fails; with it, passes.
- [x] `go build ./...`, `task lint` (0 issues), `task test` (full suite) green.

## Note for reviewer

Needs a **release (v0.0.31)** once merged — the ToolHive side just bumps the dependency (its own conversion is already correct; the content simply never reached it). This also fixes embedded resources in `GetPrompt`, not just tool calls.

Generated with [Claude Code](https://claude.com/claude-code)
