### PR TITLE
Add Environment field to BaseConfig

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,33 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Environment identifies the deployment tier a service is running in.
+// Several services independently reimplement this as a freeform string
+// (e.g. for gating dev-only behavior); Environment gives them one validated
+// type instead.
+type Environment string
+
+const (
+	// EnvironmentDevelopment is a local or shared development deployment.
+	EnvironmentDevelopment Environment = "development"
+
+	// EnvironmentStaging is a pre-production deployment.
+	EnvironmentStaging Environment = "staging"
+
+	// EnvironmentProduction is a production deployment.
+	EnvironmentProduction Environment = "production"
+)
+
+// Valid reports whether e is one of the defined Environment values.
+func (e Environment) Valid() bool {
+	switch e {
+	case EnvironmentDevelopment, EnvironmentStaging, EnvironmentProduction:
+		return true
+	default:
+		return false
+	}
+}
+
 // BaseConfig holds configuration fields common to every ToolHive-ecosystem
 // service. Consuming services embed it inline in their own config struct
 // rather than referencing it as a nested field, so the fields decode at the
@@ -29,6 +56,12 @@ type BaseConfig struct {
 	// LogLevel is the minimum log level: "debug", "info", "warn", or
 	// "error". Defaults to "info" when empty.
 	LogLevel string `yaml:"logLevel"`
+
+	// Environment is the deployment tier: "development", "staging", or
+	// "production". Required — callers that gate behavior on Environment
+	// (e.g. relaxing TLS verification only in development) need an
+	// explicit value rather than a silently-defaulted one.
+	Environment Environment `yaml:"environment"`
 }
 
 // Validate checks the base fields and returns the first violation
@@ -43,6 +76,9 @@ func (c *BaseConfig) Validate() error {
 	}
 	if _, err := c.SlogLevel(); err != nil {
 		return err
+	}
+	if !c.Environment.Valid() {
+		return fmt.Errorf("environment: unknown value %q", c.Environment)
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,21 +27,33 @@ func TestBaseConfig_Validate(t *testing.T) {
 	}{
 		{
 			name: "valid with explicit level",
-			cfg:  config.BaseConfig{ServiceName: serviceName, LogLevel: levelDebug},
+			cfg: config.BaseConfig{
+				ServiceName: serviceName, LogLevel: levelDebug, Environment: config.EnvironmentDevelopment,
+			},
 		},
 		{
 			name: "valid with empty level defaults to info",
-			cfg:  config.BaseConfig{ServiceName: serviceName},
+			cfg:  config.BaseConfig{ServiceName: serviceName, Environment: config.EnvironmentProduction},
 		},
 		{
 			name:    "missing service name",
-			cfg:     config.BaseConfig{LogLevel: "info"},
+			cfg:     config.BaseConfig{LogLevel: "info", Environment: config.EnvironmentDevelopment},
 			wantErr: "serviceName is required",
 		},
 		{
 			name:    "unknown log level",
 			cfg:     config.BaseConfig{ServiceName: serviceName, LogLevel: "verbose"},
 			wantErr: `logLevel: unknown level "verbose"`,
+		},
+		{
+			name:    "missing environment",
+			cfg:     config.BaseConfig{ServiceName: serviceName},
+			wantErr: `environment: unknown value ""`,
+		},
+		{
+			name:    "unknown environment",
+			cfg:     config.BaseConfig{ServiceName: serviceName, Environment: "prod"},
+			wantErr: `environment: unknown value "prod"`,
 		},
 	}
 
@@ -58,6 +70,31 @@ func TestBaseConfig_Validate(t *testing.T) {
 			}
 			if err == nil || err.Error() != tt.wantErr {
 				t.Fatalf("Validate() = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEnvironment_Valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		env  config.Environment
+		want bool
+	}{
+		{env: config.EnvironmentDevelopment, want: true},
+		{env: config.EnvironmentStaging, want: true},
+		{env: config.EnvironmentProduction, want: true},
+		{env: "", want: false},
+		{env: "prod", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.env), func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.env.Valid(); got != tt.want {
+				t.Errorf("Environment(%q).Valid() = %v, want %v", tt.env, got, tt.want)
 			}
 		})
 	}
@@ -133,6 +170,7 @@ func TestLoad_ExtendedServiceConfig(t *testing.T) {
 	path := writeYAML(t, `
 serviceName: airlock-gateway
 logLevel: debug
+environment: staging
 gateway:
   id: gw-1
 `)
@@ -150,6 +188,9 @@ gateway:
 	}
 	if cfg.LogLevel != levelDebug {
 		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, levelDebug)
+	}
+	if cfg.Environment != config.EnvironmentStaging {
+		t.Errorf("Environment = %q, want %q", cfg.Environment, config.EnvironmentStaging)
 	}
 	if cfg.Gateway.ID != "gw-1" {
 		t.Errorf("Gateway.ID = %q, want %q", cfg.Gateway.ID, "gw-1")

--- a/config/doc.go
+++ b/config/doc.go
@@ -8,9 +8,9 @@ ToolHive-ecosystem services, plus a strict YAML loader for it.
 # Scope
 
 This package only owns fields that are truly universal across services:
-service identity and logging. It does not define per-service schema
-(database DSNs, upstream URLs, feature flags, etc.) — those belong in each
-consuming service's own config struct.
+service identity, logging, and deployment environment. It does not define
+per-service schema (database DSNs, upstream URLs, feature flags, etc.) —
+those belong in each consuming service's own config struct.
 
 # Basic Usage
 


### PR DESCRIPTION
## Summary
- Adds a validated `Environment` enum (`development`/`staging`/`production`) to `BaseConfig`, required alongside `ServiceName`.
- Several services in the org (toolhive's Sentry config, ai-gateway's webhook TLS gating) each reimplement this as an unvalidated freeform string. This gives them one shared, validated type instead.
- Stacked on #181 (adds the `config` package this depends on) — targets that branch rather than `main`.

## Test plan
- [x] `task lint` — clean
- [x] `task test` — full repo passes, including new `Environment.Valid()` table tests and updated `BaseConfig.Validate()` cases (missing/unknown environment)
- [x] `task license-check` — clean
- [x] `TestLoad_ExtendedServiceConfig` extended to cover a YAML `environment:` field end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)