### PR TITLE
Adopt go-sdk v1.7.0-pre.3 for MCP 2026-07-28 groundwork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # toolhive-core is a shared library: a pre-release go-sdk require
+      # propagates to every downstream consumer via MVS. Fail the release
+      # job so nobody accidentally tags a release pinned to a go-sdk
+      # pre-release (see the inline comment on the go-sdk require in go.mod).
+      - name: Guard against pre-release go-sdk dependency
+        run: |
+          if grep -qE 'github\.com/modelcontextprotocol/go-sdk v[0-9]+\.[0-9]+\.[0-9]+-(pre|rc)' go.mod; then
+            echo "::error file=go.mod::go.mod pins a pre-release go-sdk version; do not tag a toolhive-core release until go-sdk final ships"
+            grep -nE 'github\.com/modelcontextprotocol/go-sdk v[0-9]+\.[0-9]+\.[0-9]+-(pre|rc)' go.mod
+            exit 1
+          fi
+
       - name: Upload schema artifacts to release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,18 @@ linters:
       - linters:
           - lll
         path: .golangci.yml
+      # mcpcompat is an intentional drop-in compatibility layer for mcp-go and
+      # must keep exposing sampling/logging/roots surface that go-sdk has
+      # marked Deprecated (SEP-2577) so downstream consumers of the shim keep
+      # working unchanged. This silences ONLY those intentional SEP-2577
+      # parity deprecations, not an evergreen catch-all: every go-sdk bump
+      # MUST be re-audited (`grep -rn "SA1019\|Deprecated" mcpcompat/` against
+      # the new SDK version) to confirm no NEW, unrelated deprecation is
+      # hiding behind this exclusion.
+      - linters:
+          - staticcheck
+        text: "SA1019"
+        path: mcpcompat/
       # These are auto-generated, so it makes no sense including them.
       - linters:
           - dupl

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3 // PRE-RELEASE: do NOT tag a toolhive-core release until go-sdk v1.7.0 final ships (MCP 2026-07-28 stateless work; re-bump then)
 	github.com/modelcontextprotocol/registry v1.8.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -122,6 +122,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260523011958-0a33c5d7ca68 // indirect
 	google.golang.org/grpc v1.82.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,8 +257,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3 h1:SEAY9IduDif4iApnZgpFkjFIdo3askSGZVbZIYyTy6I=
+github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modelcontextprotocol/registry v1.8.0 h1:x/seX0ji4iqRUpSovmkBcGbxfRiZZ7dgPwBcpCJrSTM=
 github.com/modelcontextprotocol/registry v1.8.0/go.mod h1:G6AUpTpZSekQvcLl5griUjijEE8vedARE/TyCaHEFdo=
 github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=

--- a/mcpcompat/client/client_test.go
+++ b/mcpcompat/client/client_test.go
@@ -258,6 +258,75 @@ func TestOnNotification_ProgressAndLogging(t *testing.T) {
 	require.GreaterOrEqual(t, len(got), 2, "at least progress and logging notifications expected")
 }
 
+// TestInitialize_StatefulServerNegotiatesLegacyProtocolVersion verifies that
+// Initialize() against a stateful (non-stateless) shim server still
+// negotiates the shim-owned 2025-11-25 protocol version, and that subsequent
+// calls succeed.
+//
+// go-sdk v1.7 changed (*gosdk.Client).Connect to be "Modern-first": per
+// SEP-2575 it always tries the stateless server/discover RPC first, because
+// the client's default protocol version is now the SDK's latest
+// (2026-07-28). This shim's client does not opt into that (WithStateless is
+// out of scope for this PR; see PR2/PR3), so the discover probe against a
+// stateful server is rejected and go-sdk correctly falls back to the legacy
+// initialize handshake, negotiating down to LATEST_PROTOCOL_VERSION exactly
+// as it did on go-sdk v1.6. This test pins that fallback so a future go-sdk
+// bump cannot silently break it.
+func TestInitialize_StatefulServerNegotiatesLegacyProtocolVersion(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ts := newTestServer(t)
+
+	c, err := client.NewStreamableHttpClient(ts.URL)
+	require.NoError(t, err)
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	initRes, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: testClientName, Version: testClientVersion},
+		},
+	})
+	require.NoError(t, err)
+	// go-sdk v1.7's discover-first Connect must still fall back to the legacy
+	// handshake and negotiate the shim-owned 2025-11-25 constant against a
+	// stateful server.
+	assert.Equal(t, mcp.LATEST_PROTOCOL_VERSION, initRes.ProtocolVersion)
+
+	tests := []struct {
+		name string
+	}{
+		{name: "ListTools"},
+		{name: "CallTool"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			switch tc.name {
+			case "ListTools":
+				tools, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+				require.NoError(t, err)
+				require.Len(t, tools.Tools, 1)
+				assert.Equal(t, echoToolName, tools.Tools[0].Name)
+			case "CallTool":
+				callRes, err := c.CallTool(ctx, mcp.CallToolRequest{
+					Params: mcp.CallToolParams{
+						Name:      echoToolName,
+						Arguments: map[string]any{"message": "hi"},
+					},
+				})
+				require.NoError(t, err)
+				assert.False(t, callRes.IsError)
+				require.Len(t, callRes.Content, 1)
+				txt, ok := mcp.AsTextContent(callRes.Content[0])
+				require.True(t, ok)
+				assert.Equal(t, "echo: hi", txt.Text)
+			}
+		})
+	}
+}
+
 // TestSetLevel_CompatAlias verifies that the SetLevel compatibility alias
 // (mcp-go's client.Client.SetLevel idiom) delegates to SetLoggingLevel and
 // successfully sets the server's logging level. This guards against the

--- a/mcpcompat/server/discover_fallback_test.go
+++ b/mcpcompat/server/discover_fallback_test.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/client"
+	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+)
+
+// countingSessionManager is a minimal SessionIdManager test double that
+// counts Generate and Terminate calls. It stands in for ToolHive's real
+// SessionIdManager implementations (see sharedSessionManager in
+// rehydration_test.go) but is deliberately trivial: this test only needs to
+// observe how many session IDs go-sdk mints and how many it actually
+// terminates during a single client Initialize+Close, not cross-replica
+// sharing.
+//
+// Validate is intentionally NOT counted as part of the leak tripwire below:
+// the shim only calls Validate with a session ID the CLIENT sends back on a
+// later request, and the client never learns the discover-probe's session ID
+// (go-sdk only echoes the Mcp-Session-Id response header on the initialize
+// response, mcp/streamable.go:1660, not on discover). So Validate is never
+// invoked with the orphaned probe ID either — it cannot make the orphan more
+// or less observable than the Generate/Terminate delta already does.
+type countingSessionManager struct {
+	generateCalls  atomic.Int64
+	terminateCalls atomic.Int64
+}
+
+func (m *countingSessionManager) Generate() string {
+	m.generateCalls.Add(1)
+	return uuid.NewString()
+}
+
+func (*countingSessionManager) Validate(string) (bool, error) { return false, nil }
+
+func (m *countingSessionManager) Terminate(sessionID string) (bool, error) {
+	if sessionID != "" {
+		m.terminateCalls.Add(1)
+	}
+	return false, nil
+}
+
+// TestDiscoverFallback_ExtraSessionOnStatefulServer pins a real session leak
+// introduced by the go-sdk v1.7 bump, verified by reading the go-sdk v1.7.0-
+// pre.3 source (not merely inferred from behavior):
+//
+//  1. (*gosdk.Client).Connect is now "Modern-first": per SEP-2575 it always
+//     sends server/discover first, because the client's default protocol
+//     version is now the SDK's latest (2026-07-28).
+//  2. This shim's servers are stateful (WithStateless is out of scope for
+//     this PR; see PR2), so go-sdk's stateful StreamableHTTPHandler routes
+//     the session-less discover POST through its normal new-session path: it
+//     mints a session ID via SessionIdManager.Generate and dispatches the
+//     RPC to the SAME server.discover handler a stateless server would use.
+//  3. That handler UNCONDITIONALLY sets state, defeating go-sdk's own
+//     cleanup guard: server.discover calls
+//     req.Session.updateState(func(s *ServerSessionState) { s.InitializeParams
+//     = init }) (mcp/server.go:898-902). go-sdk's per-request cleanup
+//     (mcp/streamable.go:733-735) only closes an abandoned session
+//     `if session.InitializeParams() == nil` (its #578 fix) — but the
+//     discover handler just set InitializeParams, so that guard never
+//     fires. go-sdk does NOT close the discover-probe session.
+//  4. With StreamableHTTPOptions.SessionTimeout unset (this shim never sets
+//     it — and must not, see WithSessionIdManager's doc; a timeout would
+//     reap legitimate idle sessions too), go-sdk never reaps it either: the
+//     probe session lives in go-sdk's internal session map for the process
+//     lifetime.
+//  5. The client never learns the probe's session ID (go-sdk only echoes the
+//     Mcp-Session-Id response header on an initialize response, not on
+//     discover — mcp/streamable.go:1660), so it cannot terminate the probe
+//     it never asked for; it re-mints via a brand-new POST for the legacy
+//     initialize, which mints a SECOND session ID and completes normally.
+//  6. At the ToolHive layer, this shim wires SessionIdManager.Generate as
+//     go-sdk's session-ID source (build, transports.go), so the discover
+//     probe's Generate call also creates a ToolHive-side placeholder session
+//     record. OnRegisterSession only fires once initialize actually succeeds
+//     (discover ≠ initialize), so that placeholder is never promoted, and
+//     because the client never learns the probe's ID it never sends the
+//     DELETE that would call Terminate for it — the placeholder is orphaned
+//     alongside the go-sdk session.
+//
+// Both leaks are availability/resource-exhaustion concerns (a session record
+// per Modern-first Connect attempt against a stateful server, forever), not
+// confidentiality: OnRegisterSession never fired, so no identity or tool
+// overlay is ever bound to the orphan.
+//
+// KNOWN TRANSITIONAL: fixed when PR2's stateless backend path lands (no
+// discover probe against a stateless server needs the new-session path) or
+// go-sdk starts closing/timing-out discover-only sessions. Tracks the #5911
+// unexported-version-pin gap.
+func TestDiscoverFallback_ExtraSessionOnStatefulServer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mgr := &countingSessionManager{}
+	var registeredSessions atomic.Int64
+	hooks := &server.Hooks{}
+	hooks.AddOnRegisterSession(func(_ context.Context, _ server.ClientSession) {
+		registeredSessions.Add(1)
+	})
+
+	srv := server.NewMCPServer("discover-fallback-server", testClientVersion, server.WithHooks(hooks))
+	srv.AddTool(
+		mcp.NewTool("greet", mcp.WithDescription("greets")),
+		func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("hello"), nil
+		},
+	)
+
+	httpSrv := server.NewStreamableHTTPServer(srv, server.WithSessionIdManager(mgr))
+	ts := httptest.NewServer(httpSrv)
+	t.Cleanup(ts.Close)
+
+	c, err := client.NewStreamableHttpClient(ts.URL)
+	require.NoError(t, err)
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	initRes, err := c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: testClientName, Version: testClientVersion},
+		},
+	})
+	require.NoError(t, err)
+
+	// Despite go-sdk v1.7 defaulting to the discover-first Connect, a stateful
+	// server must still negotiate down to the shim-owned legacy constant.
+	assert.Equal(t, mcp.LATEST_PROTOCOL_VERSION, initRes.ProtocolVersion)
+
+	// Generate/Terminate counts are asserted together below, after Close, so
+	// the tripwire also captures the client's DELETE behavior.
+
+	// Only the session that actually completed initialize is registered with
+	// the shim; the discover probe's session is never promoted.
+	assert.EqualValues(t, 1, registeredSessions.Load(),
+		"only the legacy-initialize session should reach OnRegisterSession")
+
+	tools, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+	require.NoError(t, err)
+	require.Len(t, tools.Tools, 1)
+	assert.Equal(t, "greet", tools.Tools[0].Name)
+
+	// Close explicitly (rather than relying solely on the t.Cleanup below) so
+	// the DELETE the client sends for the ONE session ID it knows about
+	// (the legacy-initialize session) is observed before we assert the
+	// tripwire below. Close is idempotent, so the t.Cleanup call is still
+	// safe as a belt-and-braces teardown.
+	require.NoError(t, c.Close())
+
+	// Strengthened leak tripwire (black-box, via the shim's own
+	// SessionIdManager seam — go-sdk's session map is unexported and not
+	// otherwise observable from here): Generate was called twice (discover
+	// probe + legacy initialize), but Terminate was called only ONCE,
+	// because the client only ever learns and DELETEs the legacy-initialize
+	// session's ID. The discover probe's minted ID is never terminated, on
+	// either side (go-sdk's own session AND this shim's placeholder record
+	// for it) — that is the orphan this test guards against.
+	assert.EqualValues(t, 2, mgr.generateCalls.Load(),
+		"go-sdk v1.7's discover-then-fallback Connect must mint exactly two session IDs "+
+			"against a stateful server: one abandoned by the failed discover probe, "+
+			"one for the legacy initialize that actually succeeds")
+	assert.EqualValues(t, 1, mgr.terminateCalls.Load(),
+		"only the legacy-initialize session's ID is ever DELETEd by the client, "+
+			"because it never learns the discover probe's session ID")
+	assert.EqualValues(t, 1, mgr.generateCalls.Load()-mgr.terminateCalls.Load(),
+		"exactly one Generate call must be left with no matching Terminate: the orphaned "+
+			"discover-probe placeholder record. If this assertion starts failing because "+
+			"the delta went to zero, either upstream go-sdk started closing/reaping "+
+			"discover-only sessions, or PR2's stateless backend path eliminated the probe's "+
+			"new-session route — update this test (and its doc comment) to match the fix "+
+			"instead of loosening the assertion.")
+}


### PR DESCRIPTION
## Summary

**Why:** `mcpcompat` wraps go-sdk **v1.6.1**, which only speaks MCP **2025-11-25**. The MCP **2026-07-28** ("stateless") revision — no `initialize` handshake, `server/discover`, no `Mcp-Session-Id`, `ping` removed — is implemented natively by go-sdk **v1.7.x**. Downstream ToolHive currently hand-rolls the 2026-07-28 wire path because the shim can't provide it; the point of this workstream is to replace that hand-rolled code with a shim-provided path backed by the real SDK.

**What:** This is **PR1 of 3** in the Phase 1 mcpcompat stateless work — the foundational dependency bump. It does **not** add any stateless feature yet; it makes the shim build and pass on v1.7 and pins the one behavioral change the bump introduces.

- **Bump `go-sdk` v1.6.1 → v1.7.0-pre.3.** The shim compiles against v1.7 with **zero production source edits** — v1.7 is purely additive (382→491 exported symbols, no removals or signature changes), verified by an exported-symbol diff. No existing exported signature or shim-owned constant changes (drop-in contract preserved; `mcp.LATEST_PROTOCOL_VERSION` stays `2025-11-25`, error-code constants unchanged).
- **Directory-scoped `staticcheck` SA1019 exclusion for `mcpcompat/`.** v1.7 deprecates the sampling/logging/roots surface (SEP-2577) that the shim intentionally retains for `mark3labs/mcp-go` drop-in parity. The exclusion comment notes it must be re-audited on every SDK bump.
- **Regression tests** pinning the one behavioral change (see below).

## ⚠️ Pre-release dependency — do not tag a release off this

`v1.7.0` is **not final** (only `pre.1/2/3` exist, and the 2026-07-28 wire surface is still settling between them). toolhive-core is a shared library, so a pinned pre-release propagates to every consumer via MVS. This PR adds two guards:
- an inline `// PRE-RELEASE:` marker on the `go.mod` require line, and
- a **`release.yml` guard step** that fails any release job while `go.mod` still pins a go-sdk `-pre`/`-rc` version.

Re-bump to `v1.7.0` final before tagging. It's the first of a sequence and takes a pre-release dep — the code is independently mergeable and green, but please review the approach as a set.

## Behavioral change this PR documents

v1.7's client `Connect` is **Modern-first**: it probes `server/discover` before falling back to the legacy `initialize` handshake. Against a **stateful** shim server this means one `Initialize()` now:
- negotiates down to **2025-11-25** as before (wire version unchanged), but
- mints **two** sessions (`Generate`×2): the discover probe + the legacy fallback. The discover-probe session **leaks** — go-sdk's `discover` handler sets `InitializeParams` (`mcp/server.go:898-902`), defeating the `#578` cleanup guard (`mcp/streamable.go:733`), and `SessionTimeout` is unset — and the shim-layer placeholder record is never promoted/reaped.

This is an **availability concern only** (no identity/tool binding on the orphan — `OnRegisterSession` never fires). The stateful-server leak needs an upstream fix (export the client protocol-version pin, which is unexported today — the `#5911` blocker); PR2's stateless-serving path avoids it for stateless backends. The regression test asserts the `Generate`−`Terminate` delta (2−1=1) as a tripwire so a future fix fails loudly.

## Next in this series
- **PR2:** `WithStateless` server option + make the per-session projection/rehydration machinery no-op cleanly under stateless (per-request isolation).
- **PR3:** Modern client consumption surface + re-export the `-3202x` error codes / `NeedsInput()` for downstream.

## Test plan
- [x] `task test` (race) — all existing suites green + new regression tests
- [x] `task lint` — 0 issues (SA1019 exclusion resolves the intentional deprecations)
- [x] `task license-check` — clean
- [x] `go build ./...` — clean, no source edits to `mcpcompat/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)