### PR TITLE
Serve MCP 2026-07-28 stateless over Streamable HTTP

### DIFF
--- a/mcpcompat/server/server.go
+++ b/mcpcompat/server/server.go
@@ -470,7 +470,14 @@ func (s *MCPServer) AddPrompt(prompt mcp.Prompt, handler PromptHandlerFunc) {
 // syncs that session's overlay tools, resources and prompts onto its own server
 // once the OnRegisterSession hooks have run. This mirrors mcp-go, whose
 // per-session tools were dispatched per connection.
-func (s *MCPServer) buildServer(genSessionID func() string) (*gosdk.Server, error) {
+//
+// stateless MUST be true only when this server backs a StreamableHTTPServer
+// configured WithStateless(true); it is threaded through to
+// sessionDispatchMiddleware, which forces the per-request ephemeral session
+// binding for every dispatch in that mode (see bindSessionForDispatch) rather
+// than trusting the go-sdk ServerSession's ID(). Every other call site
+// (ServeStdio, SSEServer, StreamableHTTPServer.rehydrate) passes false.
+func (s *MCPServer) buildServer(genSessionID func() string, stateless bool) (*gosdk.Server, error) {
 	s.mu.RLock()
 	tools := make(map[string]ServerTool, len(s.tools))
 	for k, v := range s.tools {
@@ -549,7 +556,7 @@ func (s *MCPServer) buildServer(genSessionID func() string) (*gosdk.Server, erro
 		return nil, err
 	}
 
-	srv.AddReceivingMiddleware(s.sessionDispatchMiddleware(srv))
+	srv.AddReceivingMiddleware(s.sessionDispatchMiddleware(srv, stateless))
 	return srv, nil
 }
 
@@ -702,11 +709,12 @@ func addGlobalTool(srv *gosdk.Server, gt *gosdk.Tool, h gosdk.ToolHandler, name 
 
 // getServerFunc returns a getServer callback for the go-sdk HTTP/SSE handlers,
 // which invoke it once per new client session. genSessionID (may be nil) is the
-// session-ID generator to install on each per-session server. On a build error
-// it logs and returns nil, which the go-sdk handler surfaces as an HTTP 400.
-func (s *MCPServer) getServerFunc(genSessionID func() string) func(*http.Request) *gosdk.Server {
+// session-ID generator to install on each per-session server. stateless is
+// forwarded to buildServer (see its doc comment). On a build error it logs
+// and returns nil, which the go-sdk handler surfaces as an HTTP 400.
+func (s *MCPServer) getServerFunc(genSessionID func() string, stateless bool) func(*http.Request) *gosdk.Server {
 	return func(*http.Request) *gosdk.Server {
-		srv, err := s.buildServer(genSessionID)
+		srv, err := s.buildServer(genSessionID, stateless)
 		if err != nil {
 			if s.logger != nil {
 				s.logger.Error("building per-session MCP server", "error", err)
@@ -723,12 +731,17 @@ func (s *MCPServer) getServerFunc(genSessionID func() string) func(*http.Request
 // InitializedHandler only fires on the later notifications/initialized — and it
 // fires the before-list/before-call hooks so ToolHive's lazy per-session tool
 // injection runs before the SDK enumerates or dispatches tools.
-func (s *MCPServer) sessionDispatchMiddleware(srv *gosdk.Server) gosdk.Middleware {
+//
+// stateless is threaded through from buildServer/StreamableHTTPServer.build:
+// see bindSessionForDispatch for how it forces the per-request ephemeral
+// binding regardless of the go-sdk ServerSession's ID().
+func (s *MCPServer) sessionDispatchMiddleware(srv *gosdk.Server, stateless bool) gosdk.Middleware {
 	return func(next gosdk.MethodHandler) gosdk.MethodHandler {
 		return func(ctx context.Context, method string, req gosdk.Request) (gosdk.Result, error) {
 			ss, _ := req.GetSession().(*gosdk.ServerSession)
-			if ss != nil {
-				ctx = s.contextWithSession(ctx, ss)
+			ctx, cleanup := s.bindSessionForDispatch(ctx, ss, srv, stateless)
+			if cleanup != nil {
+				defer cleanup()
 			}
 			// Bridge the originating HTTP request's context values (identity,
 			// audit BackendInfo, telemetry) into the handler context. go-sdk
@@ -753,14 +766,86 @@ func (s *MCPServer) sessionDispatchMiddleware(srv *gosdk.Server) gosdk.Middlewar
 			// fireBeforeHooks for the extraction and fallback behavior.
 			s.fireBeforeHooks(ctx, method, req)
 			res, err := next(ctx, method, req)
+			// TODO(cacheScope): go-sdk's setDefaultCacheableValues stamps
+			// cacheScope:"public" (Cacheable.CacheScope, an IN-BODY MCP result
+			// field, NOT an HTTP header) on 2026-07-28 list/discover result
+			// bodies, but leaves ttlMs=0. Per the spec a zero TTL means
+			// "immediately stale", so a bare "public" scope with ttlMs==0 is
+			// inert: nothing may actually cache it yet. The cross-identity
+			// cache-share hazard for a per-identity-projected result only
+			// materializes once something sets a positive ttlMs. When that
+			// happens, the fix is an IN-BODY rewrite of cacheScope to
+			// "private" on per-identity-projected results — either here
+			// (this middleware already holds res) or in the vMCP envelope —
+			// NOT an HTTP Cache-Control header, which cannot neutralize a
+			// cacheScope an MCP-aware cache reads from the body. Deferred:
+			// no consumer sets a positive ttlMs yet. Tracked as follow-up.
 			if err != nil && method == string(mcp.MethodToolsCall) {
 				err = translateUnknownToolError(err, req)
 			}
-			if err == nil && method == string(mcp.MethodInitialize) && ss != nil {
+			// registerAndSync is the OnRegisterSession path (and, transitively,
+			// registers the session in the shared s.sessions registry — see
+			// NOTE(stateless-projection) on bindSessionForDispatch). Skip it
+			// entirely under stateless: a legacy (allowsessionsinstateless=1)
+			// stateless POST can carry a client-supplied Mcp-Session-Id, which
+			// would otherwise make ss.ID() non-empty even here and route this
+			// dispatch's session into the shared registry, defeating the same
+			// isolation guarantee bindSessionForDispatch enforces below.
+			if err == nil && method == string(mcp.MethodInitialize) && ss != nil && !stateless {
 				s.registerAndSync(ctx, ss, srv)
 			}
 			return res, err
 		}
+	}
+}
+
+// bindSessionForDispatch binds the ClientSession for this dispatch into ctx,
+// selecting the binding strategy for the session's shape:
+//   - no go-sdk session at all (ss==nil): nothing to bind.
+//   - the server is serving stateless (stateless==true), OR the session is a
+//     stateless temp session (ss.ID()==""): go-sdk's serveStateless builds a
+//     fresh one of these per POST, so it gets a per-request ephemeral binding
+//     (bindEphemeralSession) that MUST be torn down via the returned cleanup
+//     once this dispatch returns — see contextWithSession for why a stateless
+//     session must never be looked up/created in the shared s.sessions
+//     registry (cross-identity disclosure).
+//   - any other (stateful) session: looked up or created in the shared
+//     registry as before (contextWithSession); no cleanup needed.
+//
+// The stateless check is NOT redundant with ss.ID()=="": go-sdk's
+// allowsessionsinstateless=1 MCPGODEBUG compatibility flag (off by default)
+// makes a legacy (<2026-07-28) stateless POST carry a client-supplied
+// Mcp-Session-Id through to ss.ID(), so ss.ID() can be non-empty even though
+// go-sdk still builds a brand-new, per-POST temp session under the hood. Were
+// the ID()=="" check the only gate, two callers sending that same id would
+// collapse onto ONE clientSession in the shared registry — a cross-identity
+// leak that defeats the isolation this function exists to guarantee. Forcing
+// the ephemeral path whenever stateless is true closes that gap regardless of
+// what ID string go-sdk happens to hand back.
+//
+// NOTE(stateless-projection): per-identity capability projection under
+// stateless only ever reaches the before-list/before-call TOOLS hooks fired
+// by sessionDispatchMiddleware (fireBeforeHooks): resources, resource
+// templates and prompts have no equivalent before-hook seam, and
+// registerAndSync/OnRegisterSession (where those overlays are normally
+// installed) never fires for an ephemeral binding. So under stateless,
+// resources/resource-templates/prompts are served from the global/
+// server-level set, not projected per identity. This is a functional scoping
+// gap, not an isolation leak: no shared state is exposed. See WithStateless's
+// doc comment (transports.go) for the full account and the tracked follow-up.
+//
+// Extracted out of sessionDispatchMiddleware to keep that function under the
+// gocyclo budget.
+func (s *MCPServer) bindSessionForDispatch(
+	ctx context.Context, ss *gosdk.ServerSession, srv *gosdk.Server, stateless bool,
+) (context.Context, func()) {
+	switch {
+	case ss == nil:
+		return ctx, nil
+	case stateless || ss.ID() == "":
+		return s.bindEphemeralSession(ctx, ss, srv)
+	default:
+		return s.contextWithSession(ctx, ss), nil
 	}
 }
 

--- a/mcpcompat/server/server_internal_test.go
+++ b/mcpcompat/server/server_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -121,7 +122,7 @@ func TestForgetSession_ClosesNotifChannel(t *testing.T) {
 func TestSetSessionTools_NonObjectSchemaDoesNotPanic(t *testing.T) {
 	t.Parallel()
 	s := NewMCPServer("s", "1")
-	srv, err := s.buildServer(nil)
+	srv, err := s.buildServer(nil, false)
 	require.NoError(t, err)
 
 	cs := s.sessionFor("sid-bad-schema")
@@ -195,7 +196,7 @@ func TestBuildServer_GlobalAndSessionTools(t *testing.T) {
 	// Building the global server (with the globally-registered tool) must succeed.
 	// Per-session overlays are no longer baked in here; they are synced onto the
 	// per-session server by syncSessionTools once the session registers.
-	srv, err := s.buildServer(nil)
+	srv, err := s.buildServer(nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 
@@ -218,7 +219,7 @@ func TestBuildServer_WithSessionIDGenerator(t *testing.T) {
 	called := false
 	gen := func() string { called = true; return "generated-id" }
 
-	srv, err := s.buildServer(gen)
+	srv, err := s.buildServer(gen, false)
 	require.NoError(t, err)
 	require.NotNil(t, srv)
 	// The generator is installed on the server (invoked by the SDK per new
@@ -366,4 +367,79 @@ func TestNormalizeObjectSchema(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestBindSessionForDispatch_StatelessForcesEphemeralRegardlessOfSessionID is
+// the regression for the "allowsessionsinstateless bypass" finding: go-sdk's
+// (off-by-default) allowsessionsinstateless=1 MCPGODEBUG compatibility flag
+// lets a legacy (<2026-07-28) stateless POST carry a client-supplied
+// Mcp-Session-Id all the way to ss.ID(), even though go-sdk still builds a
+// brand-new, per-POST temp session under the hood. Before this fix,
+// bindSessionForDispatch gated on ss.ID()=="" alone, so that non-empty,
+// attacker-or-caller-supplied ID would route through contextWithSession into
+// the SHARED s.sessions registry — meaning two concurrent callers presenting
+// the SAME session id would collapse onto ONE clientSession (cross-identity
+// bleed), silently defeating the isolation this package is built to
+// guarantee.
+//
+// The MCPGODEBUG env var is read once at process init (see go-sdk's
+// mcpgodebug package), so it cannot be toggled from a test to reproduce this
+// via a real HTTP round trip. Instead this test drives the exact shim-level
+// invariant directly: it connects two go-sdk ServerSessions that both carry
+// the SAME non-"" session ID (constructed the same way
+// StreamableHTTPServer.rehydrate builds a session with a caller-chosen ID,
+// via a StreamableServerTransport{SessionID: ...} + Server.Connect) and calls
+// bindSessionForDispatch(..., stateless=true) for each. It asserts:
+//  1. both dispatches take the ephemeral (cleanup-bearing) path despite a
+//     non-empty ss.ID();
+//  2. the shared s.sessions registry is NEVER populated; and
+//  3. the two dispatches get their OWN, independent ClientSession — proving
+//     isolation holds even when both callers present the identical ID.
+func TestBindSessionForDispatch_StatelessForcesEphemeralRegardlessOfSessionID(t *testing.T) {
+	t.Parallel()
+	s := NewMCPServer("s", "1")
+	srv, err := s.buildServer(nil, true)
+	require.NoError(t, err)
+
+	const sharedAttackerID = "attacker-shared-session-id"
+	connect := func() *gosdk.ServerSession {
+		transport := &gosdk.StreamableServerTransport{SessionID: sharedAttackerID, Stateless: true}
+		ss, err := srv.Connect(context.Background(), transport, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = ss.Close() })
+		return ss
+	}
+
+	ssA := connect()
+	ssB := connect()
+	require.Equal(t, sharedAttackerID, ssA.ID(), "test setup: session must carry the shared client-supplied ID")
+	require.Equal(t, sharedAttackerID, ssB.ID(), "test setup: session must carry the shared client-supplied ID")
+
+	ctxA, cleanupA := s.bindSessionForDispatch(context.Background(), ssA, srv, true)
+	require.NotNil(t, cleanupA,
+		"stateless dispatch must always take the ephemeral (cleanup-bearing) path, even with a non-empty ss.ID()")
+	defer cleanupA()
+
+	ctxB, cleanupB := s.bindSessionForDispatch(context.Background(), ssB, srv, true)
+	require.NotNil(t, cleanupB,
+		"stateless dispatch must always take the ephemeral (cleanup-bearing) path, even with a non-empty ss.ID()")
+	defer cleanupB()
+
+	// The shared registry must never have been touched by either dispatch: a
+	// non-empty, client-supplied session id must never route through
+	// contextWithSession/sessionFor into s.sessions when the server is
+	// stateless.
+	sharedRegistryCount := 0
+	s.sessions.Range(func(any, any) bool { sharedRegistryCount++; return true })
+	assert.Zero(t, sharedRegistryCount,
+		"s.sessions must stay empty under stateless dispatch even when requests carry a shared session id")
+
+	// Each dispatch must have been bound its OWN ephemeral ClientSession, not
+	// a shared one keyed by the identical ID.
+	csA := ClientSessionFromContext(ctxA)
+	csB := ClientSessionFromContext(ctxB)
+	require.NotNil(t, csA)
+	require.NotNil(t, csB)
+	assert.NotSame(t, csA, csB,
+		"each stateless dispatch must get its own ephemeral session, even under a shared client-supplied session id")
 }

--- a/mcpcompat/server/session.go
+++ b/mcpcompat/server/session.go
@@ -248,8 +248,23 @@ type sessionContextKey struct{}
 
 // contextWithSession looks up (or creates) the clientSession for the given
 // go-sdk ServerSession and stores it in the context.
+//
+// SECURITY: a stateless temp session (go-sdk's serveStateless creates one per
+// POST, with ID()=="" — the legacy-id compatibility path that would give it a
+// non-empty ID is off by default) must NEVER be looked up or created here.
+// sessionFor keys its registry by session ID, so calling it with "" would
+// LoadOrStore ONE shared clientSession for every concurrent stateless request,
+// regardless of caller identity — a cross-identity tool/resource/prompt
+// disclosure. The dispatch middleware (sessionDispatchMiddleware ->
+// bindEphemeralSession) already binds THIS request's own ephemeral
+// ClientSession into ctx before any handler that calls this function runs, so
+// returning ctx unchanged for ss.ID()=="" preserves that per-request binding
+// rather than clobbering it with a shared one.
 func (s *MCPServer) contextWithSession(ctx context.Context, ss *gosdk.ServerSession) context.Context {
 	if ss == nil {
+		return ctx
+	}
+	if ss.ID() == "" {
 		return ctx
 	}
 	cs := s.sessionFor(ss.ID())
@@ -257,7 +272,13 @@ func (s *MCPServer) contextWithSession(ctx context.Context, ss *gosdk.ServerSess
 	return context.WithValue(ctx, sessionContextKey{}, ClientSession(cs))
 }
 
-// sessionFor returns the registered clientSession for id, creating it if needed.
+// sessionFor returns the registered clientSession for id, creating it if
+// needed. Callers must never pass "": contextWithSession diverts the
+// stateless (ss.ID()=="") case before it can reach here, and
+// bindEphemeralSession constructs its per-request ephemeral session directly
+// via newClientSession rather than through this shared registry, so a
+// ""-keyed entry — and the cross-identity bleed a shared one would cause — is
+// never created.
 func (s *MCPServer) sessionFor(id string) *clientSession {
 	if v, ok := s.sessions.Load(id); ok {
 		return v.(*clientSession)
@@ -267,14 +288,58 @@ func (s *MCPServer) sessionFor(id string) *clientSession {
 	return actual.(*clientSession)
 }
 
+// bindEphemeralSession binds a per-request ClientSession for a stateless temp
+// session (go-sdk's serveStateless creates one, with ID()=="", for every POST)
+// into ctx, WITHOUT registering it in s.sessions (see contextWithSession):
+// each stateless POST gets its own throwaway clientSession, scoped to this
+// dispatch only, so concurrent requests from different identities never share
+// state.
+//
+// The returned cleanup MUST be invoked (via defer) once this dispatch
+// returns. newClientSession starts a goroutine that drains the session's
+// notification channel for the session's lifetime; because this ephemeral
+// session is never registered, forgetSession never runs for it, so the
+// returned cleanup is the only thing that closes the channel and lets that
+// goroutine exit. Without it, every stateless POST would leak one goroutine.
+func (s *MCPServer) bindEphemeralSession(
+	ctx context.Context, ss *gosdk.ServerSession, srv *gosdk.Server,
+) (context.Context, func()) {
+	cs := newClientSession("")
+	cs.goSession.Store(ss)
+	cs.owner.Store(s)
+	cs.boundServer.Store(srv)
+	cs.Initialize()
+	ctx = context.WithValue(ctx, sessionContextKey{}, ClientSession(cs))
+	return ctx, func() { cs.notifClose.Do(func() { close(cs.notifCh) }) }
+}
+
 // registerAndSync registers the session for the given go-sdk ServerSession,
 // firing the OnRegisterSession hooks exactly once and then reconciling any
 // per-session tool/resource/prompt overlay the hooks installed onto srv (the go-sdk
 // server bound to this session). It is invoked from the initialize dispatch
 // middleware (matching mcp-go's on-initialize timing) and, defensively, from the
 // InitializedHandler; the once-guard makes the second call a cheap no-op.
+//
+// NOTE(stateless-projection): this is also the ONLY path that fires
+// OnRegisterSession, which is where SessionWithResources/
+// SessionWithResourceTemplates/SessionWithPrompts overlays are normally
+// installed. sessionDispatchMiddleware (server.go) never calls this function
+// under stateless (it skips the call outright when stateless is true, and
+// separately this function no-ops for any ss.ID()==""), so under stateless
+// those three overlays are never installed and resources/resource-templates/
+// prompts are served from the global/server-level set rather than projected
+// per identity. Tools are the one exception: fireBeforeHooks (server.go)
+// fires the before-list/before-call TOOLS hooks directly from the dispatch
+// middleware on every request, independent of registration, so per-identity
+// tool projection still works under stateless. See WithStateless's doc
+// comment (transports.go) for the full account of this known limitation.
 func (s *MCPServer) registerAndSync(ctx context.Context, ss *gosdk.ServerSession, srv *gosdk.Server) {
-	if ss == nil {
+	// ss.ID()=="" is a stateless temp session: it has no initialize/
+	// notifications-initialized handshake to register (go-sdk's
+	// serveStateless never calls the InitializedHandler either), and
+	// registering it here would mean sessionFor("") — the exact shared-state
+	// hazard contextWithSession's doc comment describes. No-op.
+	if ss == nil || ss.ID() == "" {
 		return
 	}
 	cs := s.sessionFor(ss.ID())
@@ -455,7 +520,10 @@ func (s *MCPServer) syncSessionPrompts(srv *gosdk.Server, cs *clientSession) {
 }
 
 // isLocalSession reports whether the session ID was initialized on this server
-// instance (see MCPServer.localSessions).
+// instance (see MCPServer.localSessions). Stateless requests never reach the
+// StreamableHTTPServer code paths that call this (ServeHTTP short-circuits
+// stateless serving before any session-ID-keyed lookup), so id=="" is not a
+// case this needs to special-case.
 func (s *MCPServer) isLocalSession(id string) bool {
 	_, ok := s.localSessions.Load(id)
 	return ok
@@ -467,6 +535,13 @@ func (s *MCPServer) isLocalSession(id string) bool {
 // the drain goroutine started in newClientSession exits, preventing a goroutine
 // leak per closed session.
 func (s *MCPServer) forgetSession(id string) {
+	// id=="" would otherwise LoadAndDelete/close the shared entry a stateless
+	// contextWithSession call must never create in the first place; guard
+	// defensively since forgetSession is reachable from the DELETE path with
+	// whatever Mcp-Session-Id header the client sent.
+	if id == "" {
+		return
+	}
 	v, ok := s.sessions.LoadAndDelete(id)
 	s.localSessions.Delete(id)
 	if ok {

--- a/mcpcompat/server/stateless_test.go
+++ b/mcpcompat/server/stateless_test.go
@@ -1,0 +1,468 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mcp "github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+)
+
+// TestStateless_BasicRequestResponse verifies the happy path for MCP
+// 2026-07-28 stateless serving: a POST with no Mcp-Session-Id is answered
+// (200, application/json) directly, with no Mcp-Session-Id in the response
+// either — there is no session to hand a client an ID for.
+func TestStateless_BasicRequestResponse(t *testing.T) {
+	t.Parallel()
+
+	mcpSrv := server.NewMCPServer("stateless", "1.0.0")
+	addGreetTool(mcpSrv)
+	s := server.NewStreamableHTTPServer(mcpSrv, server.WithStateless(true))
+	ts := httptest.NewServer(s)
+	// t.Cleanup, not defer: the subtests below call t.Parallel() and so pause
+	// until this function returns, resuming afterward — a plain defer would
+	// close ts before they run. Cleanup runs only once every subtest completes.
+	t.Cleanup(ts.Close)
+
+	t.Run("tools/list", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		resp := postRPC(ctx, t, ts.URL, "", `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.True(t, strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json"),
+			"stateless responses must still reply application/json (JSONResponse mode)")
+		assert.Empty(t, resp.Header.Get("Mcp-Session-Id"), "a stateless response must never carry a session ID")
+		r := readFirstResult(t, resp)
+		require.Nil(t, r.Error, "tools/list should not error")
+		var res struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		}
+		require.NoError(t, json.Unmarshal(r.Result, &res))
+		names := make([]string, 0, len(res.Tools))
+		for _, tl := range res.Tools {
+			names = append(names, tl.Name)
+		}
+		assert.Contains(t, names, "greet")
+	})
+
+	t.Run("tools/call", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		body := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"greet","arguments":{}}}`
+		resp := postRPC(ctx, t, ts.URL, "", body)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.True(t, strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json"))
+		assert.Empty(t, resp.Header.Get("Mcp-Session-Id"))
+		r := readFirstResult(t, resp)
+		require.Nil(t, r.Error, "tools/call should not error")
+		var res struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		}
+		require.NoError(t, json.Unmarshal(r.Result, &res))
+		require.NotEmpty(t, res.Content)
+		assert.Equal(t, "hello", res.Content[0].Text)
+	})
+}
+
+// TestStateless_GETAndDELETENotAllowed verifies that a stateless server has no
+// stream to open and no session to terminate, so go-sdk answers both GET and
+// DELETE with 405, carrying the RFC 9110-mandated Allow header.
+func TestStateless_GETAndDELETENotAllowed(t *testing.T) {
+	t.Parallel()
+
+	mcpSrv := server.NewMCPServer("stateless", "1.0.0")
+	addGreetTool(mcpSrv)
+	s := server.NewStreamableHTTPServer(mcpSrv, server.WithStateless(true))
+	ts := httptest.NewServer(s)
+	// t.Cleanup, not defer: see TestStateless_BasicRequestResponse.
+	t.Cleanup(ts.Close)
+
+	tests := []struct {
+		name   string
+		method string
+	}{
+		{name: "GET", method: http.MethodGet},
+		{name: "DELETE", method: http.MethodDelete},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			req, err := http.NewRequestWithContext(ctx, tt.method, ts.URL, nil)
+			require.NoError(t, err)
+			req.Header.Set("Accept", bothAcceptMediaTypesForTest)
+			if tt.method == http.MethodDelete {
+				// A stale/foreign session ID must not change the outcome: the
+				// stateless short-circuit skips DELETE handling entirely.
+				req.Header.Set("Mcp-Session-Id", "some-stale-id")
+			}
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
+			assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+			assert.Equal(t, "POST", resp.Header.Get("Allow"),
+				"RFC 9110 section 15.5.6 requires an Allow header on 405")
+		})
+	}
+}
+
+// bothAcceptMediaTypesForTest mirrors the Accept header value the go-sdk
+// Streamable HTTP handler requires.
+const bothAcceptMediaTypesForTest = "application/json, text/event-stream"
+
+// identityCtxKey is the context key the isolation test's HTTPContextFunc uses
+// to stash the caller's identity, read back by the before-list-tools hook.
+type identityCtxKey struct{}
+
+// identityHeader carries the test caller's identity into WithHTTPContextFunc.
+const identityHeader = "X-Test-Identity"
+
+// TestStateless_Isolation is the load-bearing security regression for this PR:
+// under go-sdk's stateless mode, every POST gets a temp session with
+// ID()=="". Before the fix, contextWithSession keyed the shared s.sessions
+// registry by "" (sessionFor("") -> LoadOrStore), so every concurrent
+// stateless request — regardless of caller identity — collapsed onto ONE
+// clientSession, meaning identity A's per-session tool overlay was visible to
+// (and clobbered by) identity B's concurrent request. This test drives many
+// concurrent identities and asserts each only ever sees its OWN
+// identity-scoped tool.
+func TestStateless_Isolation(t *testing.T) {
+	t.Parallel()
+
+	hooks := &server.Hooks{}
+	hooks.AddBeforeListTools(func(ctx context.Context, _ any, _ *mcp.ListToolsRequest) {
+		identity, _ := ctx.Value(identityCtxKey{}).(string)
+		sess := server.ClientSessionFromContext(ctx)
+		if sess == nil {
+			return
+		}
+		swt, ok := sess.(server.SessionWithTools)
+		if !ok {
+			return
+		}
+		toolName := "only_" + identity
+		swt.SetSessionTools(map[string]server.ServerTool{
+			toolName: {
+				Tool: mcp.NewTool(toolName, mcp.WithDescription("identity-scoped tool")),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+		})
+	})
+
+	// No global tools: every tool observed must have come from the per-request
+	// overlay the hook above installs.
+	mcpSrv := server.NewMCPServer("iso", "1.0.0", server.WithHooks(hooks), server.WithToolCapabilities(false))
+	s := server.NewStreamableHTTPServer(
+		mcpSrv,
+		server.WithStateless(true),
+		server.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
+			return context.WithValue(ctx, identityCtxKey{}, r.Header.Get(identityHeader))
+		}),
+	)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	const goroutines = 50
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		identity, other := "A", "B"
+		if g%2 == 1 {
+			identity, other = "B", "A"
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				names, err := statelessListToolNames(ts.URL, identity)
+				if err != nil {
+					errCh <- fmt.Errorf("identity %s: %w", identity, err)
+					return
+				}
+				if !containsName(names, "only_"+identity) {
+					errCh <- fmt.Errorf("identity %s: response missing its own tool only_%s (got %v)",
+						identity, identity, names)
+					return
+				}
+				if containsName(names, "only_"+other) {
+					errCh <- fmt.Errorf("CROSS-IDENTITY LEAK: identity %s observed only_%s (got %v)",
+						identity, other, names)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+// TestStateless_Isolation_SharedClientSuppliedSessionID is a second angle on
+// the same isolation guarantee as TestStateless_Isolation, but with every
+// concurrent request carrying the SAME (stale/attacker-chosen)
+// Mcp-Session-Id header. This is the header shape go-sdk's (off-by-default)
+// allowsessionsinstateless=1 MCPGODEBUG compatibility flag would carry through
+// to the go-sdk ServerSession's ID() on a legacy (<2026-07-28) stateless POST
+// — see bindSessionForDispatch (server.go) for why a non-empty ss.ID() must
+// not, by itself, be trusted to route into the shared session registry under
+// stateless. This test cannot toggle that env var (read once at process
+// init; see TestBindSessionForDispatch_StatelessForcesEphemeralRegardlessOfSessionID
+// for the direct unit-level proof), but it pins the observable, end-to-end
+// behavior: even with every request presenting the identical session id
+// header, each identity only ever sees its own per-request tool overlay.
+func TestStateless_Isolation_SharedClientSuppliedSessionID(t *testing.T) {
+	t.Parallel()
+
+	hooks := &server.Hooks{}
+	hooks.AddBeforeListTools(func(ctx context.Context, _ any, _ *mcp.ListToolsRequest) {
+		identity, _ := ctx.Value(identityCtxKey{}).(string)
+		sess := server.ClientSessionFromContext(ctx)
+		if sess == nil {
+			return
+		}
+		swt, ok := sess.(server.SessionWithTools)
+		if !ok {
+			return
+		}
+		toolName := "only_" + identity
+		swt.SetSessionTools(map[string]server.ServerTool{
+			toolName: {
+				Tool: mcp.NewTool(toolName, mcp.WithDescription("identity-scoped tool")),
+				Handler: func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("ok"), nil
+				},
+			},
+		})
+	})
+
+	mcpSrv := server.NewMCPServer("iso-shared-id", "1.0.0", server.WithHooks(hooks), server.WithToolCapabilities(false))
+	s := server.NewStreamableHTTPServer(
+		mcpSrv,
+		server.WithStateless(true),
+		server.WithHTTPContextFunc(func(ctx context.Context, r *http.Request) context.Context {
+			return context.WithValue(ctx, identityCtxKey{}, r.Header.Get(identityHeader))
+		}),
+	)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	const goroutines = 50
+	const iterations = 100
+	const sharedStaleSessionID = "attacker-shared-session-id"
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		identity, other := "A", "B"
+		if g%2 == 1 {
+			identity, other = "B", "A"
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				names, err := statelessListToolNames(ts.URL, identity, sharedStaleSessionID)
+				if err != nil {
+					errCh <- fmt.Errorf("identity %s: %w", identity, err)
+					return
+				}
+				if !containsName(names, "only_"+identity) {
+					errCh <- fmt.Errorf("identity %s: response missing its own tool only_%s (got %v)",
+						identity, identity, names)
+					return
+				}
+				if containsName(names, "only_"+other) {
+					errCh <- fmt.Errorf("CROSS-IDENTITY LEAK (shared session id): identity %s observed only_%s (got %v)",
+						identity, other, names)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+// statelessListToolNames issues a stateless tools/list POST carrying the
+// given identity header and, if sessionID is non-empty, a Mcp-Session-Id
+// header set to it (exercising the "client sends a session id under
+// stateless" shape without relying on go-sdk actually honoring it). It
+// returns the returned tool names.
+func statelessListToolNames(url, identity string, sessionID ...string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", bothAcceptMediaTypesForTest)
+	req.Header.Set("MCP-Protocol-Version", "2025-06-18")
+	req.Header.Set(identityHeader, identity)
+	if len(sessionID) > 0 && sessionID[0] != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID[0])
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	var r rpcResult
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, err
+	}
+	if r.Error != nil {
+		return nil, fmt.Errorf("rpc error: %s", r.Error.Message)
+	}
+	var res struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(r.Result, &res); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(res.Tools))
+	for _, tl := range res.Tools {
+		names = append(names, tl.Name)
+	}
+	return names, nil
+}
+
+func containsName(names []string, name string) bool {
+	for _, n := range names {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// statelessSpySessionManager is a SessionIdManager test double that records
+// how many times each method was invoked, via atomic counters so it can be
+// safely read from the test goroutine after concurrent driving from the
+// server. Mirrors the sharedSessionManager pattern in rehydration_test.go
+// (named distinctly from discover_fallback_test.go's countingSessionManager,
+// which counts a different, narrower subset for a different test).
+type statelessSpySessionManager struct {
+	generateCalls  atomic.Int64
+	validateCalls  atomic.Int64
+	terminateCalls atomic.Int64
+}
+
+func (m *statelessSpySessionManager) Generate() string {
+	m.generateCalls.Add(1)
+	return "should-never-be-called"
+}
+
+func (m *statelessSpySessionManager) Validate(string) (bool, error) {
+	m.validateCalls.Add(1)
+	return false, nil
+}
+
+func (m *statelessSpySessionManager) Terminate(string) (bool, error) {
+	m.terminateCalls.Add(1)
+	return false, nil
+}
+
+// TestStateless_SessionIdManagerNeverConsulted verifies that a configured
+// SessionIdManager is inert under WithStateless(true): go-sdk's stateless
+// path never consults GetSessionID, and the shim's own DELETE/rehydration/
+// local-session-validation branches (which would otherwise drive
+// Validate/Terminate) are skipped entirely by the ServeHTTP short-circuit.
+func TestStateless_SessionIdManagerNeverConsulted(t *testing.T) {
+	t.Parallel()
+
+	mgr := &statelessSpySessionManager{}
+	mcpSrv := server.NewMCPServer("stateless", "1.0.0")
+	addGreetTool(mcpSrv)
+	s := server.NewStreamableHTTPServer(mcpSrv, server.WithStateless(true), server.WithSessionIdManager(mgr))
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	listResp := postRPC(ctx, t, ts.URL, "", `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	listResult := readFirstResult(t, listResp)
+	require.Nil(t, listResult.Error)
+
+	callBody := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"greet","arguments":{}}}`
+	callResp := postRPC(ctx, t, ts.URL, "", callBody)
+	callResult := readFirstResult(t, callResp)
+	require.Nil(t, callResult.Error)
+
+	getReq, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	getReq.Header.Set("Accept", bothAcceptMediaTypesForTest)
+	getResp, err := http.DefaultClient.Do(getReq)
+	require.NoError(t, err)
+	_ = getResp.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, getResp.StatusCode)
+
+	delReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, ts.URL, nil)
+	require.NoError(t, err)
+	delReq.Header.Set("Mcp-Session-Id", "some-stale-id")
+	delResp, err := http.DefaultClient.Do(delReq)
+	require.NoError(t, err)
+	_ = delResp.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, delResp.StatusCode)
+
+	assert.Equal(t, int64(0), mgr.generateCalls.Load(), "Generate must never be called under stateless serving")
+	assert.Equal(t, int64(0), mgr.validateCalls.Load(), "Validate must never be called under stateless serving")
+	assert.Equal(t, int64(0), mgr.terminateCalls.Load(), "Terminate must never be called under stateless serving")
+}
+
+// TestStateful_RegressionSessionIDStillIssued pins the divergence: a server
+// explicitly configured WithStateless(false) (the default) still runs go-sdk's
+// stateful path, so an initialize response still carries an Mcp-Session-Id and
+// the session is usable on follow-up requests. This guards against a future
+// change accidentally flipping the default or breaking the stateful path
+// while adding stateless support.
+func TestStateful_RegressionSessionIDStillIssued(t *testing.T) {
+	t.Parallel()
+
+	mcpSrv := server.NewMCPServer("stateful", "1.0.0")
+	addGreetTool(mcpSrv)
+	s := server.NewStreamableHTTPServer(mcpSrv, server.WithStateless(false))
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	sid := initSession(t, ts.URL)
+	assert.NotEmpty(t, sid, "a stateful initialize response must carry a session ID")
+	assert.Contains(t, listToolNames(t, ts.URL, sid), "greet")
+}

--- a/mcpcompat/server/transports.go
+++ b/mcpcompat/server/transports.go
@@ -60,7 +60,7 @@ type stdioConfig struct{}
 // ServeStdio runs the MCP server over stdio until the context is done. It
 // mirrors mcp-go's server.ServeStdio.
 func ServeStdio(server *MCPServer, _ ...StdioOption) error {
-	srv, err := server.buildServer(nil)
+	srv, err := server.buildServer(nil, false)
 	if err != nil {
 		return err
 	}
@@ -92,6 +92,11 @@ type StreamableHTTPServer struct {
 	// Host header). mcp-go had no such protection; local proxies with custom Host
 	// headers need it disabled. See WithDisableLocalhostProtection.
 	disableLocalhostProtection bool
+	// stateless enables MCP 2026-07-28 stateless Streamable HTTP serving
+	// (go-sdk's StreamableHTTPOptions.Stateless): every POST is served by a
+	// fresh, temporary session (no initialize handshake, no Mcp-Session-Id) that
+	// go-sdk tears down when the request completes. See WithStateless.
+	stateless bool
 
 	once     sync.Once
 	handler  http.Handler
@@ -207,6 +212,52 @@ func WithDisableLocalhostProtection(disable bool) StreamableHTTPOption {
 	return func(s *StreamableHTTPServer) { s.disableLocalhostProtection = disable }
 }
 
+// WithStateless enables MCP 2026-07-28 stateless Streamable HTTP serving.
+// Under go-sdk's stateless mode there is no initialize handshake and no
+// Mcp-Session-Id: every POST is dispatched against a fresh, temporary session
+// that go-sdk discards once the request completes, and GET/DELETE are
+// answered 405 (a stateless server has no stream to open and no session to
+// terminate). See ServeHTTP for how this short-circuits the shim's stateful
+// session bookkeeping (rehydration routing, local-session validation, DELETE
+// handling).
+//
+// Legacy (<2026-07-28) clients are NOT rejected under stateless: go-sdk still
+// answers their requests, just in a degraded, sessionless form — no session
+// id is issued, and there is no elicitation, no server->client notifications,
+// and no resumability, because none of those have anywhere to go without a
+// persistent session/standalone stream. This mode is not Modern-protocol-only;
+// it changes how EVERY client (legacy or modern) is served.
+//
+// A SessionIdManager configured via WithSessionIdManager is inert in this
+// mode: go-sdk's stateless path never consults GetSessionID, and there is no
+// session ID for Validate/Terminate to act on.
+//
+// KNOWN LIMITATION — per-identity projection is TOOLS-only under stateless:
+// ToolHive's per-session capability projection (SessionWithTools/
+// SessionWithResources/SessionWithResourceTemplates/SessionWithPrompts) is
+// normally installed by the OnRegisterSession hook, which fires from
+// registerAndSync on the initialize/notifications-initialized handshake.
+// Stateless serving has no such handshake — every request gets a fresh
+// ephemeral session (see bindSessionForDispatch) and registerAndSync never
+// runs for it — so OnRegisterSession never fires and that overlay path is
+// unavailable. The ONLY per-identity projection seam that survives under
+// stateless is the before-list/before-call TOOLS hooks (fireBeforeHooks),
+// because the shim fires those directly from sessionDispatchMiddleware ahead
+// of every dispatch, independent of registration. mcp-go's Hooks type (which
+// this shim mirrors) has no equivalent before-list-resources/
+// before-list-prompts/before-read-resource/before-get-prompt seam, so
+// resources, resource templates, and prompts are served from the global/
+// server-level set under stateless, not projected per identity — the tools
+// path is projected; those are not. This is a functional scoping gap (results
+// are global/empty, not cross-identity-leaked — isolation is intact) tracked
+// as a known limitation to be addressed when per-identity resource/prompt
+// projection is needed under stateless serving. No consumer currently wires
+// this shim path for stateless projection, so the Hooks API is intentionally
+// NOT expanded to cover it yet.
+func WithStateless(stateless bool) StreamableHTTPOption {
+	return func(s *StreamableHTTPServer) { s.stateless = stateless }
+}
+
 // WithHTTPContextFunc installs a per-request context customizer.
 //
 // Context values injected here are applied to ALL POSTs, including the
@@ -244,12 +295,16 @@ func WithHTTPContextFunc(fn HTTPContextFunc) StreamableHTTPOption {
 func (s *StreamableHTTPServer) build() {
 	s.once.Do(func() {
 		var gen func() string
-		if s.sessionIDMgr != nil {
+		// Belt-and-suspenders: under Stateless, go-sdk's serveStateless never
+		// calls GetSessionID (see WithStateless), so installing the manager's
+		// Generate here would be dead code at best; omitting it makes that
+		// explicit and guarantees the manager is never invoked in this mode.
+		if s.sessionIDMgr != nil && !s.stateless {
 			gen = s.sessionIDMgr.Generate
 		}
 		// Validate the server configuration once up-front so a bad registration
 		// surfaces as a clean 500 rather than a per-request nil.
-		if _, err := s.mcp.buildServer(gen); err != nil {
+		if _, err := s.mcp.buildServer(gen, s.stateless); err != nil {
 			s.buildErr = err
 			return
 		}
@@ -264,13 +319,16 @@ func (s *StreamableHTTPServer) build() {
 			// protection off, restoring mcp-go's acceptance of local proxies
 			// with custom Host headers.
 			DisableLocalhostProtection: s.disableLocalhostProtection,
+			// Stateless propagates MCP 2026-07-28 stateless serving to go-sdk.
+			// See WithStateless.
+			Stateless: s.stateless,
 		}
 		// A fresh go-sdk server per client session lets each session carry its own
 		// tool/resource overlay (mcp-go's per-session projection), synced by the
 		// registration middleware buildServer installs. The heartbeat keep-alive
 		// is applied at the HTTP layer (keepAliveWriter, see WithHeartbeatInterval),
 		// not through go-sdk's active KeepAlive.
-		s.handler = gosdk.NewStreamableHTTPHandler(s.mcp.getServerFunc(gen), opts)
+		s.handler = gosdk.NewStreamableHTTPHandler(s.mcp.getServerFunc(gen, s.stateless), opts)
 	})
 }
 
@@ -336,7 +394,25 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	// is best-effort for notifications. A proper fix awaits go-sdk per-request
 	// context propagation (upstream ask).
 	defer s.mcp.clearPendingRequestContext(nonce)
-	// DELETE terminates the session. mcp-go answered 200 and drove the supplied
+
+	// Stateless short-circuit. The identity contextFunc, the denial gate, and
+	// the nonce bridge above have already run, so per-identity projection and
+	// authz still apply; everything below this point is stateful-only session
+	// bookkeeping (DELETE handling, cross-replica rehydration routing,
+	// local-session revalidation) that does not apply here. go-sdk's
+	// serveStateless builds a brand-new temporary session per POST (never
+	// consulting Mcp-Session-Id or a SessionIdManager) and answers GET/DELETE
+	// with 405, so any Mcp-Session-Id a client sends on a stateless request is
+	// simply ignored — matching go-sdk, and skipping this session machinery
+	// entirely is what makes that safe (see contextWithSession/
+	// bindEphemeralSession in session.go for the per-request isolation this
+	// depends on).
+	if s.stateless {
+		s.handler.ServeHTTP(w, r)
+		return
+	}
+
+	// DELETE terminates the session (stateful only). mcp-go answered 200 and drove the supplied
 	// SessionIdManager's Terminate; go-sdk answers 204 and manages its own session
 	// map. Rewrite the status to 200 for compatibility and forward the termination
 	// to the manager so ToolHive's session storage is cleaned up in lockstep.
@@ -352,7 +428,8 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Cross-replica routing: a request carrying a session ID that was NOT
+	// Cross-replica routing (stateful only; unreachable when s.stateless, which
+	// returns above). A request carrying a session ID that was NOT
 	// initialized on this instance (its initialize handshake happened on another
 	// replica) cannot be served by the go-sdk StreamableHTTPHandler, which 404s
 	// any session ID it did not create. Validate it against the shared
@@ -362,7 +439,8 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Local-session validation (issue #156, item U5): a session initialized on
+	// Local-session validation (stateful only; unreachable when s.stateless,
+	// which returns above) (issue #156, item U5): a session initialized on
 	// THIS instance is trusted by the local go-sdk handler, but mcp-go validated
 	// every request. When a shared SessionIdManager is configured, validate local
 	// sessions on every request too, so a session terminated in the shared store
@@ -429,7 +507,11 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 // safe: it is excluded here by method, and even if wrapped the Content-Type
 // gate (application/json under JSONResponse) would keep the ticker off.
 func (s *StreamableHTTPServer) wrapKeepAlive(w http.ResponseWriter, r *http.Request) (http.ResponseWriter, func()) {
-	if r.Method != http.MethodGet || s.heartbeat <= 0 {
+	// Under Stateless, go-sdk answers every GET with 405 (no session, no
+	// stream to keep alive), so the keep-alive is never legitimate here
+	// regardless of method; excluding it explicitly avoids wrapping a
+	// ResponseWriter that will only ever carry an error body.
+	if r.Method != http.MethodGet || s.heartbeat <= 0 || s.stateless {
 		return w, func() {}
 	}
 	k := newKeepAliveWriter(w, s.heartbeat, s.mcp.logger)
@@ -533,7 +615,11 @@ func (s *StreamableHTTPServer) rehydrate(r *http.Request, sid string) (*rehydrat
 		return rt, nil
 	}
 
-	srv, err := s.mcp.buildServer(nil)
+	// Rehydration only ever runs on the stateful path (ServeHTTP's stateless
+	// short-circuit returns before serveRehydrated could be reached), and the
+	// reconstructed session below is deliberately a full, stateful session
+	// (seeded state, resumable), so this is never stateless.
+	srv, err := s.mcp.buildServer(nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -640,11 +726,12 @@ func WithMessageEndpoint(endpoint string) SSEOption {
 
 func (s *SSEServer) build() {
 	s.once.Do(func() {
-		if _, err := s.mcp.buildServer(nil); err != nil {
+		// The (legacy) SSE transport has no stateless mode of its own.
+		if _, err := s.mcp.buildServer(nil, false); err != nil {
 			s.buildErr = err
 			return
 		}
-		s.handler = gosdk.NewSSEHandler(s.mcp.getServerFunc(nil), nil)
+		s.handler = gosdk.NewSSEHandler(s.mcp.getServerFunc(nil, false), nil)
 	})
 }
 


### PR DESCRIPTION
## Summary

**Why:** PR1 (#185) put go-sdk v1.7.0-pre.3 in place. This is **PR2 of 3** — the actual stateless *serving* capability. It lets `mcpcompat`'s Streamable HTTP server answer the MCP **2026-07-28** revision (POST-only, `GET`/`DELETE` → 405, a fresh temporary session per POST with no `Mcp-Session-Id`, `server/discover` answered natively) via go-sdk's `StreamableHTTPOptions.Stateless`. It's the first piece that will let downstream ToolHive retire its hand-rolled Modern dispatch.

**What:** a new additive `WithStateless(bool)` option, plus the work to make the shim's per-session projection machinery correct **and safe** under stateless — where there's no `initialize` handshake and no `Mcp-Session-Id`.

## The security-critical part: per-request isolation

Under stateless, go-sdk hands each POST a temporary session with `ID() == ""`. The shim must **never** key its shared session registry on the empty string — otherwise every concurrent request would share one `clientSession` (one `boundServer`, one tools map) and leak one identity's projected tools to another.

- Each stateless dispatch gets its own **unstored ephemeral `clientSession`**, bound to that request's **per-request go-sdk server** (`getServer` runs per POST), so concurrent identities are fully isolated at both the shim and SDK layers.
- The ephemeral-vs-shared decision is gated on the server's **stateless mode**, not merely `ID() == ""`. This closes the `allowsessionsinstateless` compat-flag path (under which a stateless request *can* carry a client-supplied session id) — it can never route back to the shared registry. `registerAndSync` is likewise gated off under stateless.
- **Isolation test** (`-race`, looped): 50 concurrent goroutines across two identities, each asserting it sees only its own projected tool — plus a variant where every request carries the **same stale `Mcp-Session-Id`**, proving the guard holds even in the compat-flag scenario. Verified to fail if the shared-registry bug is reintroduced.

## Projection re-anchored onto the before-hooks

`OnRegisterSession` never fires statelessly (no `initialize`), so per-identity projection runs via `fireBeforeHooks` per request instead.

⚠️ **Known limitation (documented on `WithStateless`):** this covers **tools only**. Resources, resource-templates, and prompts fall back to the server-level set, because the drop-in Hooks API (mirroring `mark3labs/mcp-go`) has no before-hook seam for them. Expanding that API is intentionally out of scope for this PR; it's a tracked follow-up for when a consumer needs per-identity resource/prompt projection under stateless. (No consumer wires this shim path for stateless projection yet.)

## Other correctness

- `SessionIdManager` is **inert** under stateless (`Generate`/`Validate`/`Terminate` never consulted; the generator isn't even installed) — asserted by test.
- The ephemeral session's notification channel is closed at end of request (once-guarded), so its drain goroutine can't leak — even on handler panic (deferred cleanup).
- `ServeHTTP` short-circuits to the go-sdk handler **after** the identity contextFunc + authorization/denial gate + nonce bridge, so stateless POSTs are still authorized and identity-scoped, and a stale client-sent `Mcp-Session-Id` can't reach rehydration/validation/DELETE.
- Legacy (<2026-07-28) clients are still served under stateless, in a degraded sessionless form — documented; it's not Modern-only.

## Deferred (tracked, commented in-code)
go-sdk stamps `cacheScope:"public"` on 2026-07-28 `list`/`discover` **result bodies**. It's inert while `ttlMs == 0` (spec: zero TTL ⇒ immediately stale), but a per-identity-projected result should carry `cacheScope:"private"` via an **in-body rewrite** (here or in the vMCP envelope — *not* an HTTP `Cache-Control` header, which an MCP-aware cache wouldn't honor) once a positive TTL is in play. Deferred; data itself is correctly isolated today.

## Reviewer notes
- The isolation test is a probabilistic concurrency guard (50×100 contended ops under `-race`); it fails deterministically enough when the bug is present.
- Every stateless POST rebuilds a go-sdk server and spins a short-lived drain goroutine — heavier than stateful's once-per-session, acceptable.

## Depends on
Builds on #185 (already merged). Same **pre-release** constraint applies — the `release.yml` guard blocks tagging a release until go-sdk v1.7.0 final.

## Test plan
- [x] `task test` (race) — all suites green incl. the looped isolation tests (ran ×3 extra for flake confidence)
- [x] `task lint` — 0 issues
- [x] `task license-check` — clean
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)