### PR TITLE
Review fixes for #189: detect input-required prompt/resource results

### DIFF
--- a/mcpcompat/client/client.go
+++ b/mcpcompat/client/client.go
@@ -17,7 +17,7 @@
 // (ClientSessionOptions.protocolVersion) reachable only through the
 // *gosdk.ClientSessionOptions parameter of Client.Connect, and this shim's
 // Initialize always passes nil there, so it cannot pin a backend to, say,
-// 2025-11-25 even when that would be desirable. See issue #5911; the fix would
+// 2025-11-25 even when that would be desirable. See stacklok/toolhive#5911; the fix would
 // be to ask upstream to export that field (or add an option to set it).
 //
 // Stability: Alpha.
@@ -176,17 +176,19 @@ func WithSamplingHandler(h SamplingHandler) ClientOption {
 //
 // Disabling MRTR surfaces the input-required result to the caller instead of
 // auto-fulfilling and retrying: the client returns the input-required result
-// directly, and the caller can detect it via mcp.CallToolResult.NeedsInput
-// (which reports the underlying gosdk result's wire "resultType" field).
+// directly, and the caller can detect it via mcp.CallToolResult.NeedsInput,
+// mcp.GetPromptResult.NeedsInput, or mcp.ReadResourceResult.NeedsInput
+// (each reporting the underlying gosdk result's wire "resultType" field) for
+// tools/call, prompts/get, and resources/read respectively.
 //
 // NOTE: reading the input requests and fulfilling/retrying the call through
-// the shim is NOT yet supported — the shim's CallToolResult does not model
+// the shim is NOT yet supported — the shim's result types do not model
 // go-sdk's InputRequests/RequestState fields, only the NeedsInput
 // classification.
 //
-// Must be set before Initialize; the underlying go-sdk option
-// (gosdk.ClientOptions.MultiRoundTrip) is only consulted when the client
-// connects.
+// Must be set before Initialize: the shim calls gosdk.NewClient — which reads
+// gosdk.ClientOptions.MultiRoundTrip to decide whether to install its
+// multi-round-trip middleware — inside Initialize, before Connect runs.
 func WithoutMultiRoundTrip() ClientOption {
 	return func(c *Client) { c.disableMultiRoundTrip = true }
 }
@@ -452,6 +454,7 @@ func (c *Client) ReadResource(ctx context.Context, request mcp.ReadResourceReque
 // explicitly to the concrete text/blob mcp-go type instead.
 func convertReadResourceResult(res *gosdk.ReadResourceResult) *mcp.ReadResourceResult {
 	out := &mcp.ReadResourceResult{}
+	out.SetNeedsInput(res.NeedsInput())
 	if len(res.Meta) > 0 {
 		out.Meta = mcp.NewMetaFromMap(map[string]any(res.Meta))
 	}
@@ -512,6 +515,7 @@ func (c *Client) GetPrompt(ctx context.Context, request mcp.GetPromptRequest) (*
 // content is re-marshaled and decoded via mcp.UnmarshalContent instead.
 func convertGetPromptResult(res *gosdk.GetPromptResult) (*mcp.GetPromptResult, error) {
 	out := &mcp.GetPromptResult{Description: res.Description}
+	out.SetNeedsInput(res.NeedsInput())
 	if len(res.Meta) > 0 {
 		out.Meta = mcp.NewMetaFromMap(map[string]any(res.Meta))
 	}

--- a/mcpcompat/client/client_test.go
+++ b/mcpcompat/client/client_test.go
@@ -5,6 +5,7 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	gosdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -363,6 +365,13 @@ func TestSetLevel_CompatAlias(t *testing.T) {
 // the test server.
 const needsInputToolName = "needs-input"
 
+// elicitModeForm and needsInputMessage are the ElicitParams fields shared by
+// the MRTR opt-out test servers below.
+const (
+	elicitModeForm    = "form"
+	needsInputMessage = "need more info"
+)
+
 // newMRTRTestServer stands up a real go-sdk MCP server, served stateless (so
 // the shim client negotiates MCP 2026-07-28 rather than falling back to the
 // legacy handshake; see TestInitialize_StatefulServerNegotiatesLegacyProtocolVersion),
@@ -381,7 +390,7 @@ func newMRTRTestServer(t *testing.T, calls *int32) *httptest.Server {
 			atomic.AddInt32(calls, 1)
 			return &gosdk.CallToolResult{
 				InputRequests: gosdk.InputRequestMap{
-					"q1": &gosdk.ElicitParams{Mode: "form", Message: "need more info"},
+					"q1": &gosdk.ElicitParams{Mode: elicitModeForm, Message: needsInputMessage},
 				},
 			}, nil
 		})
@@ -454,6 +463,90 @@ func TestWithoutMultiRoundTrip(t *testing.T) {
 		_, err = c.CallTool(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{Name: needsInputToolName},
 		})
-		assert.Error(t, err, "the auto MRTR loop must fail without an elicitation handler")
+		require.Error(t, err, "the auto MRTR loop must fail without an elicitation handler")
+		// Pin the actual go-sdk contract ((*Client).elicit's rejection when no
+		// elicitation handler is registered) rather than accepting any error, so
+		// an unrelated failure (e.g. a transport EOF) can't satisfy this test.
+		var wireErr *jsonrpc.Error
+		require.True(t, errors.As(err, &wireErr), "expected a *jsonrpc.Error, got %T: %v", err, err)
+		assert.Equal(t, int64(jsonrpc.CodeInvalidParams), wireErr.Code)
+		assert.Equal(t, "client does not support elicitation", wireErr.Message)
 	})
+}
+
+// needsInputPromptName and needsInputResourceURI are the prompt/resource used
+// by the prompts/get and resources/read MRTR opt-out tests below.
+const (
+	needsInputPromptName  = "needs-input-prompt"
+	needsInputResourceURI = "test://needs-input-resource"
+)
+
+// newMRTRPromptResourceTestServer stands up a real go-sdk MCP server, served
+// stateless (see newMRTRTestServer), exposing a prompt and a resource whose
+// handlers always return an input-required result (InputRequests set, no
+// Messages/Contents).
+func newMRTRPromptResourceTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := gosdk.NewServer(&gosdk.Implementation{Name: "mrtr-server", Version: testClientVersion}, nil)
+	srv.AddPrompt(&gosdk.Prompt{Name: needsInputPromptName, Description: "always requires further client input"},
+		func(context.Context, *gosdk.GetPromptRequest) (*gosdk.GetPromptResult, error) {
+			return &gosdk.GetPromptResult{
+				InputRequests: gosdk.InputRequestMap{
+					"q1": &gosdk.ElicitParams{Mode: elicitModeForm, Message: needsInputMessage},
+				},
+			}, nil
+		})
+	srv.AddResource(&gosdk.Resource{URI: needsInputResourceURI, Name: "needs-input-resource"},
+		func(context.Context, *gosdk.ReadResourceRequest) (*gosdk.ReadResourceResult, error) {
+			return &gosdk.ReadResourceResult{
+				InputRequests: gosdk.InputRequestMap{
+					"q1": &gosdk.ElicitParams{Mode: elicitModeForm, Message: needsInputMessage},
+				},
+			}, nil
+		})
+	handler := gosdk.NewStreamableHTTPHandler(
+		func(*http.Request) *gosdk.Server { return srv }, &gosdk.StreamableHTTPOptions{Stateless: true},
+	)
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestWithoutMultiRoundTrip_PromptAndResource verifies the client.
+// WithoutMultiRoundTrip opt-out also surfaces input-required results for
+// prompts/get and resources/read (not just tools/call): go-sdk's MRTR
+// middleware intercepts all three methods, and the shim's GetPromptResult and
+// ReadResourceResult must classify them via NeedsInput just like
+// CallToolResult does.
+func TestWithoutMultiRoundTrip_PromptAndResource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ts := newMRTRPromptResourceTestServer(t)
+
+	c, err := client.NewStreamableHttpClientWithOpts(
+		ts.URL, nil, []client.ClientOption{client.WithoutMultiRoundTrip()},
+	)
+	require.NoError(t, err)
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: testClientName, Version: testClientVersion},
+		},
+	})
+	require.NoError(t, err)
+
+	promptRes, err := c.GetPrompt(ctx, mcp.GetPromptRequest{
+		Params: mcp.GetPromptParams{Name: needsInputPromptName},
+	})
+	require.NoError(t, err)
+	assert.True(t, promptRes.NeedsInput())
+
+	resourceRes, err := c.ReadResource(ctx, mcp.ReadResourceRequest{
+		Params: mcp.ReadResourceParams{URI: needsInputResourceURI},
+	})
+	require.NoError(t, err)
+	assert.True(t, resourceRes.NeedsInput())
 }

--- a/mcpcompat/mcp/jsonrpc.go
+++ b/mcpcompat/mcp/jsonrpc.go
@@ -322,13 +322,15 @@ const (
 // MCP error codes
 const (
 	// RESOURCE_NOT_FOUND indicates that the requested resource was not found.
+	//
+	// Legacy: replaced by INVALID_PARAMS. Implementations of MCP 2026-07-28+
+	// MUST NOT emit this code, but clients SHOULD still accept it from older
+	// servers.
 	RESOURCE_NOT_FOUND = -32002
 
-	// URL_ELICITATION_REQUIRED is the error code for when URL elicitation is required.
-	URL_ELICITATION_REQUIRED = -32042
-
 	// HEADER_MISMATCH indicates that HTTP headers do not match the
-	// corresponding values sent in the initial InitializeRequest.
+	// corresponding values in the request body, or that required headers
+	// are missing or malformed.
 	HEADER_MISMATCH = -32020
 
 	// MISSING_REQUIRED_CLIENT_CAPABILITIES indicates that the client did not
@@ -338,6 +340,12 @@ const (
 	// UNSUPPORTED_PROTOCOL_VERSION indicates that the requested protocol
 	// version is not supported by the receiving party.
 	UNSUPPORTED_PROTOCOL_VERSION = -32022
+
+	// URL_ELICITATION_REQUIRED is the error code for when URL elicitation is required.
+	//
+	// Legacy: MCP 2025-11-25 only. Implementations of MCP 2026-07-28+ MUST NOT
+	// emit this code.
+	URL_ELICITATION_REQUIRED = -32042
 )
 
 // EmptyResult represents a response that indicates success but carries no data.

--- a/mcpcompat/mcp/prompts.go
+++ b/mcpcompat/mcp/prompts.go
@@ -105,6 +105,40 @@ type GetPromptResult struct {
 	// An optional description for the prompt.
 	Description string          `json:"description,omitempty"`
 	Messages    []PromptMessage `json:"messages"`
+
+	// resultType captures the "resultType" wire field go-sdk emits for MCP
+	// 2026-07-28+ multi round-trip requests (SEP-2322): "complete" or
+	// "input_required". Unlike CallToolResult, this type has no custom
+	// UnmarshalJSON, so it cannot be populated that way; instead
+	// mcpcompat/client's converter (which constructs this type directly from a
+	// go-sdk result) populates it via SetNeedsInput. See NeedsInput.
+	resultType string
+}
+
+// NeedsInput reports whether this result requires further client input before
+// the prompt can be resolved. It mirrors go-sdk's GetPromptResult.NeedsInput,
+// which classifies MCP 2026-07-28+ multi round-trip requests (SEP-2322)
+// results via the wire "resultType" field ("input_required" vs "complete").
+//
+// NeedsInput is only meaningful when multi round-trip handling is disabled on
+// the client (see client.WithoutMultiRoundTrip): with it enabled (the
+// default), the client auto-fulfills server input requests and retries
+// internally, so a GetPromptResult reaching the caller never reports
+// NeedsInput true.
+func (r GetPromptResult) NeedsInput() bool {
+	return r.resultType == resultTypeInputRequired
+}
+
+// SetNeedsInput marks whether this result requires further client input
+// (SEP-2322 multi round-trip). It exists so mcpcompat/client can populate the
+// classification when constructing this type directly from a go-sdk result;
+// see NeedsInput.
+func (r *GetPromptResult) SetNeedsInput(needsInput bool) {
+	if needsInput {
+		r.resultType = resultTypeInputRequired
+		return
+	}
+	r.resultType = ""
 }
 
 // PromptOption is a function that configures a Prompt.

--- a/mcpcompat/mcp/resources.go
+++ b/mcpcompat/mcp/resources.go
@@ -191,4 +191,39 @@ type ReadResourceParams struct {
 type ReadResourceResult struct {
 	Result
 	Contents []ResourceContents `json:"contents"` // Can be TextResourceContents or BlobResourceContents
+
+	// resultType captures the "resultType" wire field go-sdk emits for MCP
+	// 2026-07-28+ multi round-trip requests (SEP-2322): "complete" or
+	// "input_required". Unlike CallToolResult, this type has no custom
+	// UnmarshalJSON, so it cannot be populated that way; instead
+	// mcpcompat/client's converter (which constructs this type directly from a
+	// go-sdk result) populates it via SetNeedsInput. See NeedsInput.
+	resultType string
+}
+
+// NeedsInput reports whether this result requires further client input before
+// the resource read can be resolved. It mirrors go-sdk's
+// ReadResourceResult.NeedsInput, which classifies MCP 2026-07-28+ multi
+// round-trip requests (SEP-2322) results via the wire "resultType" field
+// ("input_required" vs "complete").
+//
+// NeedsInput is only meaningful when multi round-trip handling is disabled on
+// the client (see client.WithoutMultiRoundTrip): with it enabled (the
+// default), the client auto-fulfills server input requests and retries
+// internally, so a ReadResourceResult reaching the caller never reports
+// NeedsInput true.
+func (r ReadResourceResult) NeedsInput() bool {
+	return r.resultType == resultTypeInputRequired
+}
+
+// SetNeedsInput marks whether this result requires further client input
+// (SEP-2322 multi round-trip). It exists so mcpcompat/client can populate the
+// classification when constructing this type directly from a go-sdk result;
+// see NeedsInput.
+func (r *ReadResourceResult) SetNeedsInput(needsInput bool) {
+	if needsInput {
+		r.resultType = resultTypeInputRequired
+		return
+	}
+	r.resultType = ""
 }

--- a/mcpcompat/mcp/tools.go
+++ b/mcpcompat/mcp/tools.go
@@ -282,6 +282,12 @@ func (r *CallToolResult) UnmarshalJSON(data []byte) error {
 // default), the client auto-fulfills server input requests and retries
 // internally, so a CallToolResult reaching the caller never reports
 // NeedsInput true.
+//
+// A present-but-unrecognized resultType (neither "complete" nor
+// "input_required") also reports false here, even though the spec requires
+// clients to treat such a value as invalid rather than as a completed
+// result. A caller needing strict conformance cannot rely on NeedsInput
+// alone to detect that case, since resultType is not otherwise exposed.
 func (r CallToolResult) NeedsInput() bool {
 	return r.resultType == resultTypeInputRequired
 }

--- a/mcpcompat/mcp/tools_needsinput_test.go
+++ b/mcpcompat/mcp/tools_needsinput_test.go
@@ -65,3 +65,19 @@ func TestCallToolResult_NeedsInput_ZeroValue(t *testing.T) {
 	var r mcp.CallToolResult
 	assert.False(t, r.NeedsInput())
 }
+
+// TestCallToolResult_MarshalJSON_DropsResultType guards the documented
+// contract that resultType is populated by UnmarshalJSON but not re-emitted
+// by MarshalJSON (see the resultType field doc on CallToolResult): an
+// unmarshal -> marshal round-trip must not resurface it on the wire.
+func TestCallToolResult_MarshalJSON_DropsResultType(t *testing.T) {
+	t.Parallel()
+
+	var r mcp.CallToolResult
+	require.NoError(t, json.Unmarshal([]byte(`{"content":[],"resultType":"input_required"}`), &r))
+	require.True(t, r.NeedsInput())
+
+	data, err := json.Marshal(r)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "resultType")
+}


### PR DESCRIPTION
Stacked on top of #189 (base is `feat/mcpcompat-modern-client-surface`, not `main`) so @JAORMX keeps control of the merge and I keep my review on #189. Merge or cherry-pick at your discretion; if you'd rather these were squashed into your commit, say so and I'll rebase them in.

## The one that matters: input-required prompt/resource results were undetectable

`WithoutMultiRoundTrip()` opts out of go-sdk's automatic MRTR handling for **all three** MRTR-capable methods — go-sdk's `clientMultiRoundTripMiddleware` intercepts `tools/call`, `prompts/get` **and** `resources/read` (`mrtr.go:76-79`), and its own `MultiRoundTripOptions.Disabled` doc names all three `NeedsInput` methods as the caller's contract. But only `CallToolResult` modeled `resultType`.

`CallTool` works because it converts via `jsonConvert`. `convertGetPromptResult` / `convertReadResourceResult` are hand-written field-by-field (their `Content` / `ResourceContents` interface fields can't survive a JSON round-trip), so they dropped `resultType` before the caller could see it.

Reproduced before the fix — `GetPrompt` against a stateless 2026-07-28 backend whose handler returns `InputRequests`:

```
GetPrompt err=<nil>
shim result: desc="" messages=0
```

`err == nil`, zero messages, no way to tell it apart from an empty completed result. The draft spec's MRTR page lists all three operations as returning `InputRequiredResult`.

Fix: `NeedsInput` on `GetPromptResult` and `ReadResourceResult` mirroring `CallToolResult`, populated in both converters from go-sdk's `NeedsInput()`. The live and `isResume()` paths both route through the converters, so both are covered (go-sdk's own `UnmarshalJSON` populates `resultType` on the resume path before the converter runs).

## Doc corrections

- **`HEADER_MISMATCH`** said headers must match "the initial `InitializeRequest`". 2026-07-28 is stateless with no handshake; `-32020` validates headers against the *same request's own body*. go-sdk's comment (`shared.go:386`) already had this right — the shim reworded it and lost the meaning.
- **Legacy codes.** Error-code block is now in numeric order, and `-32002` / `-32042` are marked legacy: the draft spec says implementations of this revision MUST NOT emit either, though clients SHOULD still accept `-32002` from older servers. They were sitting unmarked next to the three spec-current codes.
- **`NeedsInput` caveat.** A present-but-unrecognized `resultType` also reports `false`, which the spec requires clients to treat as *invalid*, not complete. Documented rather than fixed — go-sdk's `NeedsInput` is the identical comparison, and diverging would make the shim reject what go-sdk accepts. Flagging in case you want to raise it upstream.
- **`WithoutMultiRoundTrip` rationale.** go-sdk reads `ClientOptions.MultiRoundTrip` in `NewClient` (which `Initialize` calls), not in `Connect`. "Must be set before Initialize" was right for the wrong reason.
- `#5911` → `stacklok/toolhive#5911`.

## Test hardening

- `MarshalJSON` not re-emitting `resultType` was documented and honored but untested. Now guarded — a proxy that unmarshals/mutates/re-marshals a result would otherwise silently emit a stale classification if it broke.
- `default MRTR errors without a fulfilling handler` asserted only `assert.Error`, which a transport EOF would satisfy. Now pins `*jsonrpc.Error` / `-32602` / `"client does not support elicitation"`.

## Open question for you — not decided here

`GetPromptResult` / `ReadResourceResult` needed *some* way for `mcpcompat/client` to set a classification that lives in package `mcp`. This PR uses an unexported `resultType` + exported `SetNeedsInput(bool)`, matching the shape you chose on `CallToolResult`.

One reviewer argued for an exported `ResultType string` tagged `json:"-"` plus exported `ResultTypeComplete`/`ResultTypeInputRequired` consts instead, deleting both setters. The case for it:

1. `SetNeedsInput(true)` on a server-built result compiles, reads as meaningful, and does nothing — `MarshalJSON` drops the field. An imperative verb that makes no observable change is a footgun.
2. `json:"-"` on an exported field is exactly as wire-safe (`encoding/json` never touches unexported fields either way), and this package already does that in three places: `RawInputSchema`, `RawOutputSchema`, `Extra`.
3. A `bool` permanently collapses the spec's open string union; the exported field would surface the raw string on the `CallToolResult` path where it actually exists, and let the "not otherwise exposed" caveat be deleted.

Counter-argument: some cross-package channel is structurally unavoidable, and the bool loses nothing go-sdk exposes publicly anyway. Roughly +25/−40 and mechanical if you want it, but it changes your `CallToolResult` field too, so it's your call, not mine. Happy to push it to this branch if you'd like it.

## Verification

`go build ./...`, `go test -race ./mcpcompat/...`, `task lint` (0 issues), `go vet`, `task license-check` — all clean. Both new tests were confirmed to fail when the corresponding fix is reverted. Unrelated: `TestOnConnectionLost_RegisterAfterInitialize` flaked once under full-package load (a `CloseIdleConnections` transport race in `conn_lost_test.go`, untouched here) — pre-existing, worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
