### PR TITLE
feat(mcpcompat): let resource handlers return _meta

### DIFF
--- a/mcpcompat/server/server.go
+++ b/mcpcompat/server/server.go
@@ -10,7 +10,8 @@
 // Hooks and per-session interfaces, and the stdio/SSE/Streamable-HTTP
 // transports) while delegating protocol handling to a go-sdk Server. Tools,
 // resources and prompts registered here are converted to their go-sdk
-// equivalents and served by the SDK.
+// equivalents and served by the SDK, including additive result-returning
+// resource handlers that can set _meta.
 //
 // # Scope and status
 //
@@ -72,6 +73,13 @@ type ResourceHandlerFunc func(ctx context.Context, request mcp.ReadResourceReque
 // ResourceTemplateHandlerFunc handles a templated resource read.
 type ResourceTemplateHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error)
 
+// ResourceResultHandlerFunc handles a resource read and returns the full
+// result, so a handler can set _meta. It has no mcp-go equivalent — mcp-go
+// has no result-returning resource handler — so it is purely additive and
+// does not diverge from the source-compatibility contract. Calling
+// SetNeedsInput on the result has no effect on this path.
+type ResourceResultHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error)
+
 // PromptHandlerFunc handles a prompt get.
 type PromptHandlerFunc func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error)
 
@@ -100,6 +108,10 @@ type ServerTool struct {
 type ServerResource struct {
 	Resource mcp.Resource
 	Handler  ResourceHandlerFunc
+	// ResultHandler, when set, takes precedence over Handler and is the only
+	// way to return _meta on a resource read. Also backs the per-session
+	// overlay (SetSessionResources in session.go).
+	ResultHandler ResourceResultHandlerFunc
 }
 
 // ServerResourceTemplate pairs a resource template with its handler.
@@ -108,6 +120,8 @@ type ServerResource struct {
 type ServerResourceTemplate struct {
 	Template mcp.ResourceTemplate
 	Handler  ResourceTemplateHandlerFunc
+	// ResultHandler takes precedence over Handler; see ServerResource.ResultHandler.
+	ResultHandler ResourceResultHandlerFunc
 }
 
 // ServerPrompt pairs a prompt with its handler.
@@ -450,6 +464,22 @@ func (s *MCPServer) AddResourceTemplate(template mcp.ResourceTemplate, handler R
 	s.resourceTemplates[name] = ServerResourceTemplate{Template: template, Handler: handler}
 }
 
+// AddResourceWithResult registers a resource whose handler returns the full
+// result, so it can set _meta (see ResourceResultHandlerFunc).
+func (s *MCPServer) AddResourceWithResult(resource mcp.Resource, handler ResourceResultHandlerFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resources[resource.URI] = ServerResource{Resource: resource, ResultHandler: handler}
+}
+
+// AddResourceTemplateWithResult registers a resource template whose handler
+// returns the full result, so it can set _meta (see ResourceResultHandlerFunc).
+func (s *MCPServer) AddResourceTemplateWithResult(template mcp.ResourceTemplate, handler ResourceResultHandlerFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resourceTemplates[template.Name] = ServerResourceTemplate{Template: template, ResultHandler: handler}
+}
+
 // AddPrompt registers a prompt and its handler.
 func (s *MCPServer) AddPrompt(prompt mcp.Prompt, handler PromptHandlerFunc) {
 	s.mu.Lock()
@@ -591,7 +621,7 @@ func (s *MCPServer) registerGlobalFeatures(
 		if err := jsonConvert(sr.Resource, gr); err != nil {
 			return fmt.Errorf("converting resource %q: %w", sr.Resource.URI, err)
 		}
-		srv.AddResource(gr, s.wrapResourceHandler(sr.Handler))
+		srv.AddResource(gr, s.wrapResourceHandler(sr.resultHandler()))
 	}
 	for _, sp := range prompts {
 		gp := &gosdk.Prompt{}
@@ -605,7 +635,7 @@ func (s *MCPServer) registerGlobalFeatures(
 		if err := jsonConvert(srt.Template, grt); err != nil {
 			return fmt.Errorf("converting resource template %q: %w", srt.Template.Name, err)
 		}
-		h := s.wrapResourceHandler(ResourceHandlerFunc(srt.Handler))
+		h := s.wrapResourceHandler(srt.resultHandler())
 		if err := addGlobalResourceTemplate(srv, grt, h, srt.Template.Name); err != nil {
 			return err
 		}
@@ -1021,7 +1051,32 @@ func (s *MCPServer) wrapToolHandler(h ToolHandlerFunc) gosdk.ToolHandler {
 	}
 }
 
-func (s *MCPServer) wrapResourceHandler(h ResourceHandlerFunc) gosdk.ResourceHandler {
+// resourceResultHandler returns rh when set, otherwise adapts the
+// contents-returning h into a result-returning handler (today's behaviour:
+// no _meta).
+func resourceResultHandler(rh ResourceResultHandlerFunc, h ResourceHandlerFunc) ResourceResultHandlerFunc {
+	if rh != nil {
+		return rh
+	}
+	return func(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		contents, err := h(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.ReadResourceResult{Contents: contents}, nil
+	}
+}
+
+// resultHandler returns sr's effective ResourceResultHandlerFunc.
+func (sr ServerResource) resultHandler() ResourceResultHandlerFunc {
+	return resourceResultHandler(sr.ResultHandler, sr.Handler)
+}
+
+func (srt ServerResourceTemplate) resultHandler() ResourceResultHandlerFunc {
+	return resourceResultHandler(srt.ResultHandler, ResourceHandlerFunc(srt.Handler))
+}
+
+func (s *MCPServer) wrapResourceHandler(h ResourceResultHandlerFunc) gosdk.ResourceHandler {
 	return func(ctx context.Context, req *gosdk.ReadResourceRequest) (res *gosdk.ReadResourceResult, err error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -1031,12 +1086,12 @@ func (s *MCPServer) wrapResourceHandler(h ResourceHandlerFunc) gosdk.ResourceHan
 		ctx = s.contextWithSession(ctx, req.Session)
 		mreq := mcp.ReadResourceRequest{}
 		mreq.Params.URI = req.Params.URI
-		contents, err := h(ctx, mreq)
+		mres, err := h(ctx, mreq)
 		if err != nil {
 			return nil, err
 		}
 		out := &gosdk.ReadResourceResult{}
-		if err := jsonConvert(mcp.ReadResourceResult{Contents: contents}, out); err != nil {
+		if err := jsonConvert(mres, out); err != nil {
 			return nil, fmt.Errorf("converting resource result: %w", err)
 		}
 		return out, nil

--- a/mcpcompat/server/server_test.go
+++ b/mcpcompat/server/server_test.go
@@ -1172,6 +1172,279 @@ func TestSessionResourceTemplates_ListAndRead_EndToEnd(t *testing.T) {
 	require.Error(t, err, "resources/read must fail on a session without the template")
 }
 
+// TestResourceWithResult_EndToEnd is the regression anchor for the
+// result-returning resource handlers (AddResourceWithResult /
+// AddResourceTemplateWithResult): wrapResourceHandler now jsonConverts the
+// handler's whole *mcp.ReadResourceResult onto the wire instead of just
+// Contents, so a handler-set _meta key must survive a real streamable-HTTP
+// round trip alongside the contents. It also pins that the pre-existing
+// contents-only AddResource/AddResourceTemplate handlers are unaffected and
+// still produce no _meta, guarding the shared wrapResourceHandler path
+// against a regression that would leak or drop metadata.
+func TestResourceWithResult_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	const (
+		metaKey = "trace-id"
+		metaVal = "abc-123"
+
+		plainURI  = "file:///plain"
+		plainText = "plain body"
+
+		resultURI  = "file:///with-result"
+		resultText = "result body"
+
+		templateName   = "item-template"
+		uriTemplate    = "file:///items/{id}"
+		templateURI    = "file:///items/7"
+		plainTmplName  = "plain-item-template"
+		plainURITmpl   = "file:///plain-items/{id}"
+		plainTemplURI  = "file:///plain-items/7"
+		plainTemplText = "plain template body for 7"
+		resultTmplText = "result template body for 7"
+	)
+
+	tests := []struct {
+		name     string
+		register func(srv *server.MCPServer)
+		readURI  string
+		wantText string
+		wantMeta bool
+	}{
+		{
+			name: "resource: ResultHandler carries _meta",
+			register: func(srv *server.MCPServer) {
+				srv.AddResourceWithResult(mcp.Resource{URI: resultURI, Name: "with-result"},
+					func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+						res := &mcp.ReadResourceResult{
+							Contents: []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: resultText}},
+						}
+						res.Meta = mcp.NewMetaFromMap(map[string]any{metaKey: metaVal})
+						return res, nil
+					})
+			},
+			readURI:  resultURI,
+			wantText: resultText,
+			wantMeta: true,
+		},
+		{
+			name: "resource: plain Handler still works, no _meta",
+			register: func(srv *server.MCPServer) {
+				srv.AddResource(mcp.Resource{URI: plainURI, Name: "plain"},
+					func(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+						return []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: plainText}}, nil
+					})
+			},
+			readURI:  plainURI,
+			wantText: plainText,
+			wantMeta: false,
+		},
+		{
+			name: "resource template: ResultHandler carries _meta",
+			register: func(srv *server.MCPServer) {
+				srv.AddResourceTemplateWithResult(mcp.ResourceTemplate{Name: templateName, URITemplate: uriTemplate},
+					func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+						res := &mcp.ReadResourceResult{
+							Contents: []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: resultTmplText}},
+						}
+						res.Meta = mcp.NewMetaFromMap(map[string]any{metaKey: metaVal})
+						return res, nil
+					})
+			},
+			readURI:  templateURI,
+			wantText: resultTmplText,
+			wantMeta: true,
+		},
+		{
+			name: "resource template: plain Handler still works, no _meta",
+			register: func(srv *server.MCPServer) {
+				srv.AddResourceTemplate(mcp.ResourceTemplate{Name: plainTmplName, URITemplate: plainURITmpl},
+					func(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+						return []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: plainTemplText}}, nil
+					})
+			},
+			readURI:  plainTemplURI,
+			wantText: plainTemplText,
+			wantMeta: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			srv := server.NewMCPServer("resource-result-server", testClientVersion,
+				server.WithResourceCapabilities(true, true))
+			tt.register(srv)
+
+			httpSrv := server.NewStreamableHTTPServer(srv)
+			ts := httptest.NewServer(httpSrv)
+			t.Cleanup(ts.Close)
+
+			c, err := client.NewStreamableHttpClient(ts.URL)
+			require.NoError(t, err)
+			require.NoError(t, c.Start(ctx))
+			t.Cleanup(func() { _ = c.Close() })
+
+			_, err = c.Initialize(ctx, mcp.InitializeRequest{
+				Params: mcp.InitializeParams{
+					ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+					ClientInfo:      mcp.Implementation{Name: testClientName, Version: testClientVersion},
+				},
+			})
+			require.NoError(t, err)
+
+			read, err := c.ReadResource(ctx, mcp.ReadResourceRequest{Params: mcp.ReadResourceParams{URI: tt.readURI}})
+			require.NoError(t, err)
+			require.Len(t, read.Contents, 1)
+			tc, ok := read.Contents[0].(mcp.TextResourceContents)
+			require.True(t, ok, "resources/read must return text contents")
+			assert.Equal(t, tt.wantText, tc.Text, "resources/read must return the handler's contents")
+
+			if tt.wantMeta {
+				require.NotNil(t, read.Meta, "a ResultHandler's _meta must reach the client")
+				assert.Equal(t, metaVal, read.Meta.AdditionalFields[metaKey],
+					"a custom _meta key set by the handler must survive the round trip")
+			} else {
+				assert.True(t, read.Meta == nil || read.Meta.AdditionalFields[metaKey] == nil,
+					"a plain contents-only handler must not set the handler's _meta key")
+			}
+		})
+	}
+}
+
+// TestSessionResourceWithResult_EndToEnd covers the per-session resource
+// overlay path ToolHive's vMCP actually uses (SetSessionResources /
+// SetSessionResourceTemplates). It pins two things: (1) a ServerResource or
+// ServerResourceTemplate injected via the session hook with only
+// ResultHandler set carries its _meta to the client exactly like a global
+// AddResourceWithResult registration, and (2) when both Handler and
+// ResultHandler are set on the same ServerResource or ServerResourceTemplate,
+// ResultHandler takes precedence — its contents (and _meta) are what the
+// client sees, never Handler's.
+func TestSessionResourceWithResult_EndToEnd(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	const (
+		metaKey = "trace-id"
+		metaVal = "session-abc"
+
+		resultOnlyURI  = "file:///result-only"
+		resultOnlyText = "result-only body"
+
+		precedenceURI    = "file:///precedence"
+		handlerLoserText = "handler body (must lose)"
+		resultWinnerText = "result body (must win)"
+
+		templateName             = "session-template"
+		uriTemplate              = "file:///session-items/{id}"
+		templateReadURI          = "file:///session-items/9"
+		templateText             = "session template body for 9"
+		templateHandlerLoserText = "session template handler body (must lose)"
+	)
+
+	hooks := &server.Hooks{}
+	hooks.AddOnRegisterSession(func(_ context.Context, s server.ClientSession) {
+		swr, ok := s.(server.SessionWithResources)
+		require.True(t, ok, "session must implement SessionWithResources")
+		swr.SetSessionResources(map[string]server.ServerResource{
+			resultOnlyURI: {
+				Resource: mcp.Resource{URI: resultOnlyURI, Name: "result-only"},
+				ResultHandler: func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+					res := &mcp.ReadResourceResult{
+						Contents: []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: resultOnlyText}},
+					}
+					res.Meta = mcp.NewMetaFromMap(map[string]any{metaKey: metaVal})
+					return res, nil
+				},
+			},
+			precedenceURI: {
+				Resource: mcp.Resource{URI: precedenceURI, Name: "precedence"},
+				Handler: func(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+					return []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: handlerLoserText}}, nil
+				},
+				ResultHandler: func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+					return &mcp.ReadResourceResult{
+						Contents: []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: resultWinnerText}},
+					}, nil
+				},
+			},
+		})
+
+		swrt, ok := s.(server.SessionWithResourceTemplates)
+		require.True(t, ok, "session must implement SessionWithResourceTemplates")
+		swrt.SetSessionResourceTemplates(map[string]server.ServerResourceTemplate{
+			templateName: {
+				Template: mcp.ResourceTemplate{Name: templateName, URITemplate: uriTemplate},
+				Handler: func(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+					return []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: templateHandlerLoserText}}, nil
+				},
+				ResultHandler: func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+					res := &mcp.ReadResourceResult{
+						Contents: []mcp.ResourceContents{mcp.TextResourceContents{URI: req.Params.URI, Text: templateText}},
+					}
+					res.Meta = mcp.NewMetaFromMap(map[string]any{metaKey: metaVal})
+					return res, nil
+				},
+			},
+		})
+	})
+
+	srv := server.NewMCPServer("session-result-server", testClientVersion,
+		server.WithResourceCapabilities(true, true),
+		server.WithHooks(hooks),
+	)
+
+	httpSrv := server.NewStreamableHTTPServer(srv)
+	ts := httptest.NewServer(httpSrv)
+	t.Cleanup(ts.Close)
+
+	c, err := client.NewStreamableHttpClient(ts.URL)
+	require.NoError(t, err)
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: testClientName, Version: testClientVersion},
+		},
+	})
+	require.NoError(t, err)
+
+	// Per-session ResultHandler-only resource: contents AND _meta must arrive.
+	read, err := c.ReadResource(ctx, mcp.ReadResourceRequest{Params: mcp.ReadResourceParams{URI: resultOnlyURI}})
+	require.NoError(t, err)
+	require.Len(t, read.Contents, 1)
+	tc, ok := read.Contents[0].(mcp.TextResourceContents)
+	require.True(t, ok, "resources/read must return text contents")
+	assert.Equal(t, resultOnlyText, tc.Text)
+	require.NotNil(t, read.Meta, "a per-session ResultHandler's _meta must reach the client")
+	assert.Equal(t, metaVal, read.Meta.AdditionalFields[metaKey])
+
+	// Precedence: both Handler and ResultHandler set on the same ServerResource
+	// -> ResultHandler must win.
+	precRead, err := c.ReadResource(ctx, mcp.ReadResourceRequest{Params: mcp.ReadResourceParams{URI: precedenceURI}})
+	require.NoError(t, err)
+	require.Len(t, precRead.Contents, 1)
+	ptc, ok := precRead.Contents[0].(mcp.TextResourceContents)
+	require.True(t, ok, "resources/read must return text contents")
+	assert.Equal(t, resultWinnerText, ptc.Text, "ResultHandler must take precedence over Handler")
+
+	// Per-session template with both Handler and ResultHandler set: ResultHandler
+	// must win, and its contents AND _meta must arrive.
+	tmplRead, err := c.ReadResource(ctx, mcp.ReadResourceRequest{Params: mcp.ReadResourceParams{URI: templateReadURI}})
+	require.NoError(t, err)
+	require.Len(t, tmplRead.Contents, 1)
+	ttc, ok := tmplRead.Contents[0].(mcp.TextResourceContents)
+	require.True(t, ok, "resources/read must return text contents")
+	assert.Equal(t, templateText, ttc.Text, "ResultHandler must take precedence over Handler")
+	require.NotNil(t, tmplRead.Meta, "a per-session template ResultHandler's _meta must reach the client")
+	assert.Equal(t, metaVal, tmplRead.Meta.AdditionalFields[metaKey])
+}
+
 // TestCompletion_EndToEnd verifies WithCompletionHandler end-to-end: a server
 // built with a completion handler that returns fixed values for a given prompt
 // reference must (1) advertise the completions capability at initialize and (2)

--- a/mcpcompat/server/session.go
+++ b/mcpcompat/server/session.go
@@ -443,7 +443,7 @@ func (s *MCPServer) syncSessionResources(srv *gosdk.Server, cs *clientSession) {
 		if err := jsonConvert(sr.Resource, gr); err != nil {
 			continue
 		}
-		srv.AddResource(gr, s.wrapResourceHandler(sr.Handler))
+		srv.AddResource(gr, s.wrapResourceHandler(sr.resultHandler()))
 	}
 }
 
@@ -467,7 +467,7 @@ func (s *MCPServer) syncSessionResourceTemplates(srv *gosdk.Server, cs *clientSe
 			}
 			continue
 		}
-		if !s.addSessionResourceTemplate(srv, grt, ResourceHandlerFunc(srt.Handler)) {
+		if !s.addSessionResourceTemplate(srv, grt, srt.resultHandler()) {
 			if s.logger != nil {
 				s.logger.Warn("skipping per-session resource template: AddResourceTemplate rejected its URI template",
 					"template", name)
@@ -482,7 +482,7 @@ func (s *MCPServer) syncSessionResourceTemplates(srv *gosdk.Server, cs *clientSe
 // the template could not be registered, so the caller skips it rather than
 // crashing the session. Mirrors addSessionTool.
 func (s *MCPServer) addSessionResourceTemplate(
-	srv *gosdk.Server, grt *gosdk.ResourceTemplate, h ResourceHandlerFunc,
+	srv *gosdk.Server, grt *gosdk.ResourceTemplate, h ResourceResultHandlerFunc,
 ) (ok bool) {
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Closes #194. Part of stacklok/toolhive#6027.

## Problem

`wrapResourceHandler` built its result as `mcp.ReadResourceResult{Contents: contents}`, so a resource handler had no way to set `_meta` and any backend resource metadata was dropped before it reached the wire. `wrapPromptHandler` — immediately below it — already `jsonConvert`s the handler's whole result, which is why prompts keep `_meta` today and resources did not. Both ends already supported the field; only the handler signature was in the way.

## Change

Adds a result-returning handler variant alongside the existing contents-returning one:

- `ResourceResultHandlerFunc` returning `(*mcp.ReadResourceResult, error)`
- `ResultHandler` field on `ServerResource` and `ServerResourceTemplate` (takes precedence over `Handler`)
- `AddResourceWithResult` / `AddResourceTemplateWithResult`
- one adapter resolving the effective handler, so all four registration paths — global resource, global template, and both per-session overlays — gain `_meta` support
- `wrapResourceHandler` forwards the handler's whole result, mirroring `wrapPromptHandler`

Putting `ResultHandler` on the two registration structs means the per-session overlay (`SetSessionResources` / `SetSessionResourceTemplates`) is covered without a new session API — that is the path ToolHive's vMCP uses.

**Additive on purpose.** `ResourceHandlerFunc`, `ResourceTemplateHandlerFunc`, `AddResource` and `AddResourceTemplate` are untouched; existing registrations still compile. mcp-go has no result-returning resource handler, so there is no upstream shape to diverge from.

## Acceptance criteria

- [x] A resource handler can set `_meta` and it appears on the `resources/read` wire result
- [x] Existing `ResourceHandlerFunc` registrations are unchanged and still compile
- [x] Covered for both `AddResource` and `AddResourceTemplate`

## Tests

`TestResourceWithResult_EndToEnd` (table-driven) and `TestSessionResourceWithResult_EndToEnd`, both over real streamable HTTP with the mcpcompat client:

- `_meta` round-trips for global resource, global template, and the per-session overlay
- `Handler` vs `ResultHandler` precedence, for both `ServerResource` and `ServerResourceTemplate`
- plain contents-returning handlers still work and set no `_meta`

Every assertion was mutation-checked: reverting the production change makes them fail, and the "no `_meta`" assertions were confirmed non-tautological by force-attaching a meta key.

## Review notes

Verified during review, not assumed:

- **Nil-result invariant holds.** `json.Unmarshal("null", …)` is a no-op on a struct, so the unconditionally allocated `out` can never be nil. This matters beyond `stripPublicCacheScope`'s comment: go-sdk calls `setDefaultCacheableValues()` before its own nil check and would panic on a typed-nil.
- **Contents serialization is byte-identical** to before, including the nil-contents case, and cache scope is still narrowed to `private`.
- **`SetNeedsInput` has no effect on this path** — `mcp.ReadResourceResult.resultType` is unexported with no custom marshaler, so `jsonConvert` drops it. Documented on `ResourceResultHandlerFunc`.

Deliberately out of scope: a handler's `_meta` can shadow go-sdk's reserved `io.modelcontextprotocol/serverInfo` key. That hole is pre-existing and identical on `wrapToolHandler` and `wrapPromptHandler`, so it needs one shared fix rather than a resource-only patch.

`task` (lint + race tests) and `task license-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
