### PR TITLE
feat(audit): support RFC 8693 act delegation chains

### DIFF
--- a/audit/delegation.go
+++ b/audit/delegation.go
@@ -68,6 +68,15 @@ type DelegatedActor struct {
 	extra   map[string]any
 }
 
+// String implements [fmt.Stringer] so that fmt-based rendering of a hop — or of
+// any struct containing hops, such as a dereferenced DelegationChain — cannot
+// reach the unexported extra claims through %v/%+v. fmt does not consult
+// [log/slog.LogValuer], so the PII guard needs this second, fmt-side door
+// closed as well.
+func (a DelegatedActor) String() string {
+	return "{iss:" + a.Issuer + " sub:" + a.Subject + "}"
+}
+
 // Extra returns a shallow copy of the hop's extra (non-standard) claims.
 // Mutating the returned map (adding, deleting, or replacing top-level keys)
 // does not affect the hop's internal state. However, mutating a nested map
@@ -139,6 +148,9 @@ func (c *DelegationChain) IsZero() bool {
 // struct's JSON tags (including omitempty on iss/sub and malformedReason) so
 // slog and JSON output stay structurally identical.
 func (c *DelegationChain) LogValue() slog.Value {
+	if c == nil {
+		return slog.GroupValue()
+	}
 	hops := make([]map[string]string, 0, len(c.Chain))
 	for _, hop := range c.Chain {
 		// Mirror the omitempty tags on DelegatedActor so the shapes stay

--- a/audit/delegation.go
+++ b/audit/delegation.go
@@ -4,26 +4,18 @@
 package audit
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
+	"reflect"
 )
 
 // DefaultMaxDelegationDepth is the default defensive cap on delegation-chain
-// parsing. It bounds recursion on attacker-influenceable input: RFC 8693 sets
-// no limit on chain length, so a maliciously crafted token could otherwise
-// force unbounded recursion. Callers may pass a stricter maxDepth to
-// [ParseDelegationChain] to match a minting-side cap. The default is
-// intentionally larger than any known consumer's minting cap.
+// parsing. It bounds the work done on attacker-influenceable input: RFC 8693
+// sets no limit on chain length, so a maliciously crafted token could
+// otherwise force unbounded work. Callers should pass their own minting-side
+// cap as maxDepth to [ParseDelegationChain] when they have one; the default is
+// intentionally larger than any known consumer's minting cap, so that for
+// consumers passing their (smaller) mint cap, Truncated=true is a genuine
+// signal that a token came from outside their own issuance path.
 const DefaultMaxDelegationDepth = 16
-
-// ErrNotJSONObject is returned by [ParseDelegationChain] when the top-level
-// act claim value is not a JSON object (e.g. a string, number, bool, or array).
-var ErrNotJSONObject = errors.New("top-level act claim is not a JSON object")
-
-// ErrNestedActNotObject is returned by [ParseDelegationChain] when a nested
-// act member inside a delegation hop is not a JSON object.
-var ErrNestedActNotObject = errors.New("nested act claim is not a JSON object")
 
 // hopClaimIss, hopClaimSub, and hopClaimAct are the RFC 8693 claim keys
 // recognized on a delegation hop. All other keys are treated as extra
@@ -34,12 +26,39 @@ const (
 	hopClaimAct = "act"
 )
 
+// MalformedReason is a low-cardinality label describing the first
+// RFC 8693 conformance violation encountered while parsing an `act` claim.
+// It is deliberately an enum rather than free text so that it is safe to use
+// as a metric or alerting dimension.
+type MalformedReason string
+
+// Malformed reasons reported by [ParseDelegationChain]. The first violation
+// encountered wins; subsequent violations do not overwrite it.
+const (
+	// MalformedReasonActNotObject: the top-level act claim value was not a
+	// JSON object (e.g. a string, number, bool, or array).
+	MalformedReasonActNotObject MalformedReason = "act_not_object"
+	// MalformedReasonNestedActNotObject: a nested act member inside a
+	// delegation hop was not a JSON object.
+	MalformedReasonNestedActNotObject MalformedReason = "nested_act_not_object"
+	// MalformedReasonIssNotString: a hop carried an iss claim that was not a
+	// JSON string. The raw value is retained in that hop's in-memory extra
+	// claims under "iss".
+	MalformedReasonIssNotString MalformedReason = "iss_not_string"
+	// MalformedReasonSubNotString: a hop carried a sub claim that was not a
+	// JSON string. The raw value is retained in that hop's in-memory extra
+	// claims under "sub".
+	MalformedReasonSubNotString MalformedReason = "sub_not_string"
+)
+
 // DelegatedActor represents a single hop in an RFC 8693 delegation chain.
 //
-// Per-hop identity is the issuer (iss) and subject (sub) pair only, as
-// specified by RFC 8693 §6. Any other claims present on a hop are retained
-// in the in-memory-only extra map (never serialized or logged) to avoid
-// leaking Personally Identifiable Information.
+// Per-hop identity is the issuer (iss) and subject (sub) pair only: per
+// OpenID Connect Core §5.7 the (iss, sub) combination is the only stable,
+// unique actor identifier, and RFC 8693 §6 calls for data minimization. Any
+// other claims present on a hop are retained in the in-memory-only extra map
+// (never serialized or logged) to avoid leaking Personally Identifiable
+// Information.
 type DelegatedActor struct {
 	Issuer  string `json:"iss,omitempty"`
 	Subject string `json:"sub,omitempty"`
@@ -51,6 +70,11 @@ type DelegatedActor struct {
 // does not affect the hop's internal state. However, mutating a nested map
 // or slice value may share underlying data with the hop's copy. It returns
 // nil when the hop has no extra claims.
+//
+// The extra claims are deliberately excluded from JSON and slog output as a
+// PII guard, and may contain sensitive or internal claims (session
+// identifiers, emails, roles). Callers MUST NOT serialize or log the returned
+// map; doing so reintroduces the leak this design prevents.
 func (a DelegatedActor) Extra() map[string]any {
 	if len(a.extra) == 0 {
 		return nil
@@ -65,158 +89,206 @@ func (a DelegatedActor) Extra() map[string]any {
 // DelegationChain holds a flattened, ordered RFC 8693 delegation chain.
 //
 // The chain is ordered OUTERMOST-FIRST: Chain[0] is the current actor (the
-// immediate subject of the event), and the last entry is the least recent
-// (original) actor. Only the top-level event claims and Chain[0] should
-// drive access-control decisions; prior hops are informational only.
+// immediate actor of the event), and the last entry is the least recent
+// (earliest) actor. The delegating end user is NOT part of the chain: per
+// RFC 8693 it is the token's top-level sub, recorded in the event's Subjects
+// map. Per RFC 8693 §4.1, only the top-level event claims and Chain[0] may
+// drive access-control decisions; prior hops are informational only and exist
+// for audit.
 //
-// Truncated and Omitted intentionally have no omitempty tag: truncation is
-// never silent. When Truncated is true, Omitted reports how many inner hops
-// were dropped to satisfy the maxDepth cap. The outermost hops are always
-// preserved (the current actor is never dropped); only inner hops are
-// omitted.
+// Ordering rationale — do not assume, and do not "fix": current-actor-first
+// matches the read order of RFC 8693's nested act structure, and it keeps
+// Chain[0] STABLE UNDER TRUNCATION — truncation drops inner (early) hops, so
+// the one hop that may inform decisions is always at index 0, complete chain
+// or not. Beware that append-style flat formats elsewhere (Envoy XFCC,
+// GCP delegates[]) run the OPPOSITE direction (original-first); consumers
+// correlating across systems must map explicitly rather than by position
+// intuition.
+//
+// Truncated, Omitted, and Malformed intentionally have no omitempty tag:
+// an incomplete or non-conformant chain is never silently indistinguishable
+// from a complete, well-formed one. When Truncated is true, Omitted reports
+// how many inner hops were dropped to satisfy the maxDepth cap; the outermost
+// hops are always preserved (the current actor is never dropped). When
+// Malformed is true, MalformedReason carries the first conformance violation
+// encountered, and Chain holds the hops that parsed successfully before it.
 type DelegationChain struct {
-	Chain     []DelegatedActor `json:"chain"`
-	Truncated bool             `json:"truncated"`
-	Omitted   int              `json:"omitted"`
+	Chain           []DelegatedActor `json:"chain"`
+	Truncated       bool             `json:"truncated"`
+	Omitted         int              `json:"omitted"`
+	Malformed       bool             `json:"malformed"`
+	MalformedReason MalformedReason  `json:"malformedReason,omitempty"`
 }
 
-// IsEmpty reports whether the chain is nil or contains no hops.
+// IsEmpty reports whether the chain is nil or contains no hops. Note that a
+// chain with no hops may still carry audit-relevant state (Malformed); use
+// [DelegationChain.IsZero] to decide whether a chain is worth recording.
 func (c *DelegationChain) IsEmpty() bool {
 	return c == nil || len(c.Chain) == 0
+}
+
+// IsZero reports whether the chain carries no information at all: no hops,
+// no truncation, and no malformation. A zero chain is omitted from JSON and
+// log output; a non-zero chain — including a hopless but malformed one — is
+// always recorded.
+func (c *DelegationChain) IsZero() bool {
+	return c == nil || (len(c.Chain) == 0 && !c.Truncated && !c.Malformed)
+}
+
+// flagMalformed marks the chain malformed with the given reason. The first
+// reason encountered wins so that the recorded reason points at the outermost
+// (most actionable) violation.
+func (c *DelegationChain) flagMalformed(reason MalformedReason) {
+	c.Malformed = true
+	if c.MalformedReason == "" {
+		c.MalformedReason = reason
+	}
 }
 
 // ParseDelegationChain parses a raw RFC 8693 `act` claim into a flattened,
 // outermost-first [DelegationChain].
 //
-// The input is expected to be a JSON object (map) decoded via
-// [encoding/json.Unmarshal] into an `any` value (i.e. map[string]any). The
-// parser walks nested `act` claims iteratively, bounded by maxDepth, so
-// pathologically deep input cannot cause a stack overflow.
+// The input is expected to be the decoded JSON value of the `act` claim
+// (i.e. a map[string]any, or any named map type with string keys such as
+// jwt.MapClaims). The parser walks nested `act` claims iteratively, bounded
+// by maxDepth, so pathologically deep input cannot cause a stack overflow.
+//
+// ParseDelegationChain never fails: it is an audit-side parser, and an audit
+// record must be producible for exactly the tokens that violate expectations
+// (an unreadable delegation assertion is forensically distinct from "no
+// delegation"). Non-conformant input is recorded on the returned chain via
+// Malformed/MalformedReason rather than dropped or returned as an error.
+// Enforcement belongs on the issuance path, not here.
 //
 // Parsing semantics:
 //   - maxDepth <= 0 uses [DefaultMaxDelegationDepth].
-//   - A nil input yields a non-nil empty chain (&DelegationChain{}), no error.
-//   - A non-map scalar (string, float64, bool, []any) returns nil and an error
-//     whose message names the unexpected kind.
+//   - A nil input yields a zero chain (no hops, not malformed): a JSON null
+//     or absent act claim asserts no delegation.
+//   - A non-object input (string, number, bool, array) yields no hops and
+//     Malformed=true with [MalformedReasonActNotObject].
 //   - A map with no iss/sub/act yields one hop with empty Subject/Issuer
 //     (sub is conventional, not RFC-mandatory; parsing is tolerant).
-//   - A map with sub sets that hop's Subject; iss sets Issuer.
+//   - A string sub sets that hop's Subject; a string iss sets Issuer. A
+//     non-string sub or iss leaves the field empty, flags the chain malformed,
+//     and retains the raw value in the hop's in-memory extra claims — the
+//     record shows that an identifier was present but unusable.
 //   - A nested `act` map is recursed: the outer map is Chain[0], its act is
 //     Chain[1], and so on. The result is naturally outermost-first.
+//   - A nested `act` that is present but not a map (JSON null excepted, which
+//     ends the chain) keeps the hops parsed so far and flags the chain
+//     malformed with [MalformedReasonNestedActNotObject].
 //   - When the depth equals maxDepth exactly, the full chain is returned with
 //     Truncated=false and Omitted=0.
 //   - When the depth exceeds maxDepth, the OUTERMOST maxDepth hops are kept
 //     (the current actor is preserved), Truncated=true, and Omitted counts
-//     the dropped inner hops. This is truncation, not an error.
-//   - An `act` claim present but not a map (e.g. "act":"x") returns nil and
-//     an error.
+//     the dropped inner hops. A malformed node past the cap flags Malformed
+//     but is not counted as an omitted hop.
 //   - Unknown extra keys on a hop are stored in that hop's in-memory-only
-//     extra map (see [DelegatedActor.Extra]).
-func ParseDelegationChain(raw any, maxDepth int) (*DelegationChain, error) {
+//     extra map (see [DelegatedActor.Extra]) and are never serialized.
+func ParseDelegationChain(raw any, maxDepth int) *DelegationChain {
 	if maxDepth <= 0 {
 		maxDepth = DefaultMaxDelegationDepth
 	}
 
+	chain := &DelegationChain{Chain: []DelegatedActor{}}
 	if raw == nil {
-		return &DelegationChain{}, nil
+		return chain
 	}
 
-	// A non-map scalar input is invalid; the top-level act claim must be a
-	// JSON object. Reject by naming the unexpected kind.
-	switch raw.(type) {
-	case map[string]any:
-		// ok, proceed
-	case string, float64, bool, []any, json.Number:
-		return nil, fmt.Errorf("%w: expected JSON object, got %T", ErrNotJSONObject, raw)
-	default:
-		return nil, fmt.Errorf("%w: expected JSON object, got %T", ErrNotJSONObject, raw)
+	current, ok := asStringMap(raw)
+	if !ok {
+		chain.flagMalformed(MalformedReasonActNotObject)
+		return chain
 	}
 
-	chain := &DelegationChain{}
-	current := raw
-	depth := 0
-
-	for current != nil {
+	for depth := 0; ; depth++ {
 		if depth >= maxDepth {
 			// We have hit the cap. The remaining inner hops (current and any
-			// nested act beneath it) must be counted and dropped, preserving
-			// only the outermost maxDepth hops already collected.
+			// nested act beneath it) are counted and dropped, preserving only
+			// the outermost maxDepth hops already collected.
 			chain.Truncated = true
-			chain.Omitted += countRemainingHops(current)
-			return chain, nil
+			omitted, malformed := countRemainingHops(current)
+			chain.Omitted += omitted
+			if malformed {
+				chain.flagMalformed(MalformedReasonNestedActNotObject)
+			}
+			return chain
 		}
 
-		hopMap, ok := current.(map[string]any)
-		if !ok {
-			// An `act` claim present but not a map is a hard error.
-			return nil, fmt.Errorf("%w: act claim must be a JSON object", ErrNestedActNotObject)
+		hop := DelegatedActor{extra: extraClaims(current)}
+		if rawIss, present := current[hopClaimIss]; present {
+			if iss, isString := rawIss.(string); isString {
+				hop.Issuer = iss
+			} else {
+				chain.flagMalformed(MalformedReasonIssNotString)
+			}
 		}
-
-		hop := DelegatedActor{extra: extraClaims(hopMap)}
-		if iss, ok := hopMap[hopClaimIss].(string); ok {
-			hop.Issuer = iss
-		}
-		if sub, ok := hopMap[hopClaimSub].(string); ok {
-			hop.Subject = sub
+		if rawSub, present := current[hopClaimSub]; present {
+			if sub, isString := rawSub.(string); isString {
+				hop.Subject = sub
+			} else {
+				chain.flagMalformed(MalformedReasonSubNotString)
+			}
 		}
 		chain.Chain = append(chain.Chain, hop)
-		depth++
 
-		next, hasAct := hopMap[hopClaimAct]
-		if !hasAct {
-			// No further nesting; the chain is complete.
-			return chain, nil
+		next, hasAct := current[hopClaimAct]
+		if !hasAct || next == nil {
+			// No further nesting (an explicit JSON null ends the chain like
+			// an absent act); the chain is complete.
+			return chain
 		}
 
-		nextMap, ok := next.(map[string]any)
+		nextMap, ok := asStringMap(next)
 		if !ok {
-			return nil, fmt.Errorf("%w: act claim must be a JSON object", ErrNestedActNotObject)
+			// A nested act present but not an object: keep what parsed and
+			// record the violation.
+			chain.flagMalformed(MalformedReasonNestedActNotObject)
+			return chain
 		}
 		current = nextMap
 	}
-
-	return chain, nil
 }
 
-// countRemainingHops counts how many hops would follow the current node
-// (inclusive of current) down the nested `act` chain. These are the hops
-// dropped due to exceeding maxDepth. The walk is iterative (not recursive),
-// so it cannot stack-overflow; it terminates because decoded JSON is a tree
-// and cannot contain reference cycles.
-func countRemainingHops(node any) int {
+// countRemainingHops counts how many hops follow the current node (inclusive
+// of current) down the nested `act` chain. These are the hops dropped due to
+// exceeding maxDepth. The second return reports whether the walk ended on a
+// non-object act value. The walk is iterative (not recursive), so it cannot
+// stack-overflow; it terminates because decoded JSON is a tree and cannot
+// contain reference cycles.
+func countRemainingHops(node map[string]any) (int, bool) {
 	count := 0
 	current := node
-	for current != nil {
-		m, ok := current.(map[string]any)
-		if !ok {
-			// Non-map act was already validated during the main walk; treat a
-			// malformed node as a single dropped hop and stop.
-			count++
-			break
-		}
+	for {
 		count++
-		next, hasAct := m[hopClaimAct]
-		if !hasAct {
-			break
+		next, hasAct := current[hopClaimAct]
+		if !hasAct || next == nil {
+			return count, false
 		}
-		nm, ok := next.(map[string]any)
+		nm, ok := asStringMap(next)
 		if !ok {
-			count++
-			break
+			// A non-object act past the cap is a violation, not a hop.
+			return count, true
 		}
 		current = nm
 	}
-	return count
 }
 
-// extraClaims returns a shallow copy of the non-standard keys on a hop map
-// (i.e. every key except iss, sub, and act). The result is nil when there are
-// no extra claims.
+// extraClaims returns a shallow copy of the non-standard keys on a hop map:
+// every key except act, and except iss/sub when they hold their conventional
+// string type. A non-string iss/sub is retained here so the raw value stays
+// inspectable in memory after the typed field is left empty. The result is
+// nil when there are no extra claims.
 func extraClaims(hop map[string]any) map[string]any {
 	var extra map[string]any
 	for k, v := range hop {
-		if k == hopClaimIss || k == hopClaimSub || k == hopClaimAct {
+		switch k {
+		case hopClaimAct:
 			continue
+		case hopClaimIss, hopClaimSub:
+			if _, isString := v.(string); isString {
+				continue
+			}
 		}
 		if extra == nil {
 			extra = make(map[string]any)
@@ -224,4 +296,24 @@ func extraClaims(hop map[string]any) map[string]any {
 		extra[k] = v
 	}
 	return extra
+}
+
+// asStringMap converts a decoded JSON object into a map[string]any. The fast
+// path is a direct type assertion; the reflective fallback accepts named map
+// types with string keys (e.g. jwt.MapClaims) so that programmatically built
+// claim structures are not silently misread as non-objects.
+func asStringMap(v any) (map[string]any, bool) {
+	if m, ok := v.(map[string]any); ok {
+		return m, true
+	}
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() || rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String {
+		return nil, false
+	}
+	out := make(map[string]any, rv.Len())
+	iter := rv.MapRange()
+	for iter.Next() {
+		out[iter.Key().String()] = iter.Value().Interface()
+	}
+	return out, true
 }

--- a/audit/delegation.go
+++ b/audit/delegation.go
@@ -7,14 +7,16 @@ import (
 	"reflect"
 )
 
-// DefaultMaxDelegationDepth is the default defensive cap on delegation-chain
-// parsing. It bounds the work done on attacker-influenceable input: RFC 8693
-// sets no limit on chain length, so a maliciously crafted token could
-// otherwise force unbounded work. Callers should pass their own minting-side
-// cap as maxDepth to [ParseDelegationChain] when they have one; the default is
-// intentionally larger than any known consumer's minting cap, so that for
-// consumers passing their (smaller) mint cap, Truncated=true is a genuine
-// signal that a token came from outside their own issuance path.
+// DefaultMaxDelegationDepth is the default cap on how many delegation hops
+// [ParseDelegationChain] retains. It is a parse ceiling, not a minting cap:
+// RFC 8693 sets no limit on chain length, so this bounds the size of the
+// retained chain and of the emitted audit record on attacker-influenceable
+// input. It does not bound parsing work — the caller has already decoded the
+// claim. Callers should pass their own minting-side cap as maxDepth when they
+// have one; the default is intentionally larger than any known consumer's
+// minting cap, so that for consumers passing their (smaller) mint cap,
+// Truncated=true is a genuine signal that a token came from outside their own
+// issuance path.
 const DefaultMaxDelegationDepth = 16
 
 // hopClaimIss, hopClaimSub, and hopClaimAct are the RFC 8693 claim keys
@@ -88,13 +90,13 @@ func (a DelegatedActor) Extra() map[string]any {
 
 // DelegationChain holds a flattened, ordered RFC 8693 delegation chain.
 //
-// The chain is ordered OUTERMOST-FIRST: Chain[0] is the current actor (the
-// immediate actor of the event), and the last entry is the least recent
-// (earliest) actor. The delegating end user is NOT part of the chain: per
-// RFC 8693 it is the token's top-level sub, recorded in the event's Subjects
-// map. Per RFC 8693 §4.1, only the top-level event claims and Chain[0] may
-// drive access-control decisions; prior hops are informational only and exist
-// for audit.
+// The chain is ordered OUTERMOST-FIRST: Chain[0] is the current actor — the
+// party that presented the token — and the last entry is the least recent
+// (original) actor. The party on whose behalf they acted is NOT part of the
+// chain: per RFC 8693 it is the token's top-level sub, carried by the event's
+// own Subjects map; the chain never repeats it. Per RFC 8693 §4.1, only the
+// top-level event claims and Chain[0] may drive access-control decisions;
+// prior hops are informational only and exist for audit.
 //
 // Ordering rationale — do not assume, and do not "fix": current-actor-first
 // matches the read order of RFC 8693's nested act structure, and it keeps

--- a/audit/delegation.go
+++ b/audit/delegation.go
@@ -4,6 +4,7 @@
 package audit
 
 import (
+	"log/slog"
 	"reflect"
 )
 
@@ -122,19 +123,45 @@ type DelegationChain struct {
 	MalformedReason MalformedReason  `json:"malformedReason,omitempty"`
 }
 
-// IsEmpty reports whether the chain is nil or contains no hops. Note that a
-// chain with no hops may still carry audit-relevant state (Malformed); use
-// [DelegationChain.IsZero] to decide whether a chain is worth recording.
-func (c *DelegationChain) IsEmpty() bool {
-	return c == nil || len(c.Chain) == 0
-}
-
 // IsZero reports whether the chain carries no information at all: no hops,
 // no truncation, and no malformation. A zero chain is omitted from JSON and
 // log output; a non-zero chain — including a hopless but malformed one — is
 // always recorded.
 func (c *DelegationChain) IsZero() bool {
 	return c == nil || (len(c.Chain) == 0 && !c.Truncated && !c.Malformed)
+}
+
+// LogValue implements [log/slog.LogValuer] so that every handler — not just
+// JSONHandler, which happens to skip unexported fields via encoding/json —
+// sees only the promoted iss/sub of each hop. Handing the struct to a handler
+// directly would let a text or other fmt-based handler render the unexported
+// extra claims via %+v, defeating the PII guard. The emitted shape mirrors the
+// struct's JSON tags (including omitempty on iss/sub and malformedReason) so
+// slog and JSON output stay structurally identical.
+func (c *DelegationChain) LogValue() slog.Value {
+	hops := make([]map[string]string, 0, len(c.Chain))
+	for _, hop := range c.Chain {
+		// Mirror the omitempty tags on DelegatedActor so the shapes stay
+		// identical for hops with an absent iss or sub.
+		logged := make(map[string]string, 2)
+		if hop.Issuer != "" {
+			logged[hopClaimIss] = hop.Issuer
+		}
+		if hop.Subject != "" {
+			logged[hopClaimSub] = hop.Subject
+		}
+		hops = append(hops, logged)
+	}
+	attrs := []slog.Attr{
+		slog.Any("chain", hops),
+		slog.Bool("truncated", c.Truncated),
+		slog.Int("omitted", c.Omitted),
+		slog.Bool("malformed", c.Malformed),
+	}
+	if c.MalformedReason != "" {
+		attrs = append(attrs, slog.String("malformedReason", string(c.MalformedReason)))
+	}
+	return slog.GroupValue(attrs...)
 }
 
 // flagMalformed marks the chain malformed with the given reason. The first

--- a/audit/delegation.go
+++ b/audit/delegation.go
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// DefaultMaxDelegationDepth is the default defensive cap on delegation-chain
+// parsing. It bounds recursion on attacker-influenceable input: RFC 8693 sets
+// no limit on chain length, so a maliciously crafted token could otherwise
+// force unbounded recursion. Callers may pass a stricter maxDepth to
+// [ParseDelegationChain] to match a minting-side cap. The default is
+// intentionally larger than any known consumer's minting cap.
+const DefaultMaxDelegationDepth = 16
+
+// ErrNotJSONObject is returned by [ParseDelegationChain] when the top-level
+// act claim value is not a JSON object (e.g. a string, number, bool, or array).
+var ErrNotJSONObject = errors.New("top-level act claim is not a JSON object")
+
+// ErrNestedActNotObject is returned by [ParseDelegationChain] when a nested
+// act member inside a delegation hop is not a JSON object.
+var ErrNestedActNotObject = errors.New("nested act claim is not a JSON object")
+
+// hopClaimIss, hopClaimSub, and hopClaimAct are the RFC 8693 claim keys
+// recognized on a delegation hop. All other keys are treated as extra
+// (in-memory-only) claims.
+const (
+	hopClaimIss = "iss"
+	hopClaimSub = "sub"
+	hopClaimAct = "act"
+)
+
+// DelegatedActor represents a single hop in an RFC 8693 delegation chain.
+//
+// Per-hop identity is the issuer (iss) and subject (sub) pair only, as
+// specified by RFC 8693 §6. Any other claims present on a hop are retained
+// in the in-memory-only extra map (never serialized or logged) to avoid
+// leaking Personally Identifiable Information.
+type DelegatedActor struct {
+	Issuer  string `json:"iss,omitempty"`
+	Subject string `json:"sub,omitempty"`
+	extra   map[string]any
+}
+
+// Extra returns a shallow copy of the hop's extra (non-standard) claims.
+// Mutating the returned map (adding, deleting, or replacing top-level keys)
+// does not affect the hop's internal state. However, mutating a nested map
+// or slice value may share underlying data with the hop's copy. It returns
+// nil when the hop has no extra claims.
+func (a DelegatedActor) Extra() map[string]any {
+	if len(a.extra) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(a.extra))
+	for k, v := range a.extra {
+		out[k] = v
+	}
+	return out
+}
+
+// DelegationChain holds a flattened, ordered RFC 8693 delegation chain.
+//
+// The chain is ordered OUTERMOST-FIRST: Chain[0] is the current actor (the
+// immediate subject of the event), and the last entry is the least recent
+// (original) actor. Only the top-level event claims and Chain[0] should
+// drive access-control decisions; prior hops are informational only.
+//
+// Truncated and Omitted intentionally have no omitempty tag: truncation is
+// never silent. When Truncated is true, Omitted reports how many inner hops
+// were dropped to satisfy the maxDepth cap. The outermost hops are always
+// preserved (the current actor is never dropped); only inner hops are
+// omitted.
+type DelegationChain struct {
+	Chain     []DelegatedActor `json:"chain"`
+	Truncated bool             `json:"truncated"`
+	Omitted   int              `json:"omitted"`
+}
+
+// IsEmpty reports whether the chain is nil or contains no hops.
+func (c *DelegationChain) IsEmpty() bool {
+	return c == nil || len(c.Chain) == 0
+}
+
+// ParseDelegationChain parses a raw RFC 8693 `act` claim into a flattened,
+// outermost-first [DelegationChain].
+//
+// The input is expected to be a JSON object (map) decoded via
+// [encoding/json.Unmarshal] into an `any` value (i.e. map[string]any). The
+// parser walks nested `act` claims iteratively, bounded by maxDepth, so
+// pathologically deep input cannot cause a stack overflow.
+//
+// Parsing semantics:
+//   - maxDepth <= 0 uses [DefaultMaxDelegationDepth].
+//   - A nil input yields a non-nil empty chain (&DelegationChain{}), no error.
+//   - A non-map scalar (string, float64, bool, []any) returns nil and an error
+//     whose message names the unexpected kind.
+//   - A map with no iss/sub/act yields one hop with empty Subject/Issuer
+//     (sub is conventional, not RFC-mandatory; parsing is tolerant).
+//   - A map with sub sets that hop's Subject; iss sets Issuer.
+//   - A nested `act` map is recursed: the outer map is Chain[0], its act is
+//     Chain[1], and so on. The result is naturally outermost-first.
+//   - When the depth equals maxDepth exactly, the full chain is returned with
+//     Truncated=false and Omitted=0.
+//   - When the depth exceeds maxDepth, the OUTERMOST maxDepth hops are kept
+//     (the current actor is preserved), Truncated=true, and Omitted counts
+//     the dropped inner hops. This is truncation, not an error.
+//   - An `act` claim present but not a map (e.g. "act":"x") returns nil and
+//     an error.
+//   - Unknown extra keys on a hop are stored in that hop's in-memory-only
+//     extra map (see [DelegatedActor.Extra]).
+func ParseDelegationChain(raw any, maxDepth int) (*DelegationChain, error) {
+	if maxDepth <= 0 {
+		maxDepth = DefaultMaxDelegationDepth
+	}
+
+	if raw == nil {
+		return &DelegationChain{}, nil
+	}
+
+	// A non-map scalar input is invalid; the top-level act claim must be a
+	// JSON object. Reject by naming the unexpected kind.
+	switch raw.(type) {
+	case map[string]any:
+		// ok, proceed
+	case string, float64, bool, []any, json.Number:
+		return nil, fmt.Errorf("%w: expected JSON object, got %T", ErrNotJSONObject, raw)
+	default:
+		return nil, fmt.Errorf("%w: expected JSON object, got %T", ErrNotJSONObject, raw)
+	}
+
+	chain := &DelegationChain{}
+	current := raw
+	depth := 0
+
+	for current != nil {
+		if depth >= maxDepth {
+			// We have hit the cap. The remaining inner hops (current and any
+			// nested act beneath it) must be counted and dropped, preserving
+			// only the outermost maxDepth hops already collected.
+			chain.Truncated = true
+			chain.Omitted += countRemainingHops(current)
+			return chain, nil
+		}
+
+		hopMap, ok := current.(map[string]any)
+		if !ok {
+			// An `act` claim present but not a map is a hard error.
+			return nil, fmt.Errorf("%w: act claim must be a JSON object", ErrNestedActNotObject)
+		}
+
+		hop := DelegatedActor{extra: extraClaims(hopMap)}
+		if iss, ok := hopMap[hopClaimIss].(string); ok {
+			hop.Issuer = iss
+		}
+		if sub, ok := hopMap[hopClaimSub].(string); ok {
+			hop.Subject = sub
+		}
+		chain.Chain = append(chain.Chain, hop)
+		depth++
+
+		next, hasAct := hopMap[hopClaimAct]
+		if !hasAct {
+			// No further nesting; the chain is complete.
+			return chain, nil
+		}
+
+		nextMap, ok := next.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%w: act claim must be a JSON object", ErrNestedActNotObject)
+		}
+		current = nextMap
+	}
+
+	return chain, nil
+}
+
+// countRemainingHops counts how many hops would follow the current node
+// (inclusive of current) down the nested `act` chain. These are the hops
+// dropped due to exceeding maxDepth. The walk is iterative (not recursive),
+// so it cannot stack-overflow; it terminates because decoded JSON is a tree
+// and cannot contain reference cycles.
+func countRemainingHops(node any) int {
+	count := 0
+	current := node
+	for current != nil {
+		m, ok := current.(map[string]any)
+		if !ok {
+			// Non-map act was already validated during the main walk; treat a
+			// malformed node as a single dropped hop and stop.
+			count++
+			break
+		}
+		count++
+		next, hasAct := m[hopClaimAct]
+		if !hasAct {
+			break
+		}
+		nm, ok := next.(map[string]any)
+		if !ok {
+			count++
+			break
+		}
+		current = nm
+	}
+	return count
+}
+
+// extraClaims returns a shallow copy of the non-standard keys on a hop map
+// (i.e. every key except iss, sub, and act). The result is nil when there are
+// no extra claims.
+func extraClaims(hop map[string]any) map[string]any {
+	var extra map[string]any
+	for k, v := range hop {
+		if k == hopClaimIss || k == hopClaimSub || k == hopClaimAct {
+			continue
+		}
+		if extra == nil {
+			extra = make(map[string]any)
+		}
+		extra[k] = v
+	}
+	return extra
+}

--- a/audit/delegation_test.go
+++ b/audit/delegation_test.go
@@ -1,0 +1,577 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test-local constants to satisfy goconst across repeated use in fixtures.
+const (
+	testAliceEmail  = "alice@example.com"
+	testAdminRole   = "admin"
+	testSourceIP    = "10.0.0.1"
+	testActorAlice  = "alice"
+	extraClaimEmail = "email"
+)
+
+// nestedAct builds a deeply nested act chain map of the given depth where
+// each hop has iss=<label>. The outermost hop is labeled with labels[0].
+// Each hop's act points to the next, forming a chain of `depth` hops total.
+func nestedAct(depth int, labels []string) map[string]any {
+	if depth <= 0 {
+		return nil
+	}
+	hop := map[string]any{
+		hopClaimIss: labels[0],
+		hopClaimSub: labels[0] + "-sub",
+	}
+	if depth > 1 {
+		hop[hopClaimAct] = nestedAct(depth-1, labels[1:])
+	}
+	return hop
+}
+
+// labelsABC returns labels C,B,A,... so that nestedAct produces outermost=C
+// (Chain[0]=C) down to A as the innermost.
+func labelsABC(n int) []string {
+	all := []string{"C", "B", "A", "Z", "Y", "X", "W", "V", "U", "T", "S", "R", "Q", "P", "O", "N"}
+	if n <= len(all) {
+		return all[:n]
+	}
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = all[i%len(all)]
+	}
+	return out
+}
+
+func TestParseDelegationChain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		raw         any
+		maxDepth    int
+		wantErr     bool
+		errContains string
+		wantErrIs   error
+		check       func(t *testing.T, c *DelegationChain)
+	}{
+		{
+			name:     "nil input returns empty non-nil chain",
+			raw:      nil,
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.NotNil(t, c)
+				assert.True(t, c.IsEmpty(), "nil input should yield empty chain")
+				assert.False(t, c.Truncated)
+				assert.Equal(t, 0, c.Omitted)
+			},
+		},
+		{
+			name:        "string scalar returns error naming kind",
+			raw:         "not-an-object",
+			maxDepth:    DefaultMaxDelegationDepth,
+			wantErr:     true,
+			errContains: "string",
+			wantErrIs:   ErrNotJSONObject,
+		},
+		{
+			name:        "float64 scalar returns error naming kind",
+			raw:         float64(3.14),
+			maxDepth:    DefaultMaxDelegationDepth,
+			wantErr:     true,
+			errContains: "float64",
+			wantErrIs:   ErrNotJSONObject,
+		},
+		{
+			name:        "bool scalar returns error naming kind",
+			raw:         true,
+			maxDepth:    DefaultMaxDelegationDepth,
+			wantErr:     true,
+			errContains: "bool",
+			wantErrIs:   ErrNotJSONObject,
+		},
+		{
+			name:        "slice returns error naming kind",
+			raw:         []any{"x"},
+			maxDepth:    DefaultMaxDelegationDepth,
+			wantErr:     true,
+			errContains: "[]interface",
+			wantErrIs:   ErrNotJSONObject,
+		},
+		{
+			name:     "empty map yields one hop with empty subject/issuer",
+			raw:      map[string]any{},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.NotNil(t, c)
+				require.Len(t, c.Chain, 1)
+				assert.Empty(t, c.Chain[0].Subject)
+				assert.Empty(t, c.Chain[0].Issuer)
+				assert.False(t, c.Truncated)
+			},
+		},
+		{
+			name:     "sub only sets subject",
+			raw:      map[string]any{hopClaimSub: testActorAlice},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				assert.Equal(t, testActorAlice, c.Chain[0].Subject)
+				assert.Empty(t, c.Chain[0].Issuer)
+			},
+		},
+		{
+			name:     "iss and sub both set",
+			raw:      map[string]any{hopClaimIss: "issuer-1", hopClaimSub: "subject-1"},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				assert.Equal(t, "issuer-1", c.Chain[0].Issuer)
+				assert.Equal(t, "subject-1", c.Chain[0].Subject)
+			},
+		},
+		{
+			name: "one hop with nested act yields two entries outermost-first",
+			raw: map[string]any{
+				hopClaimIss: "outer",
+				hopClaimSub: "outer-sub",
+				hopClaimAct: map[string]any{
+					hopClaimIss: "inner",
+					hopClaimSub: "inner-sub",
+				},
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 2)
+				assert.Equal(t, "outer", c.Chain[0].Issuer)
+				assert.Equal(t, "inner", c.Chain[1].Issuer)
+				assert.False(t, c.Truncated)
+				assert.Equal(t, 0, c.Omitted)
+			},
+		},
+		{
+			name:     "two hops produce three entries ordered C,B,A",
+			raw:      nestedAct(3, labelsABC(3)),
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 3)
+				// outermost-first: Chain[0]=C, Chain[1]=B, Chain[2]=A
+				assert.Equal(t, "C", c.Chain[0].Issuer)
+				assert.Equal(t, "B", c.Chain[1].Issuer)
+				assert.Equal(t, "A", c.Chain[2].Issuer)
+				assert.False(t, c.Truncated)
+			},
+		},
+		{
+			name:     "depth exactly at cap yields no truncation",
+			raw:      nestedAct(16, labelsABC(16)),
+			maxDepth: 16,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 16)
+				assert.False(t, c.Truncated)
+				assert.Equal(t, 0, c.Omitted)
+			},
+		},
+		{
+			name:     "depth over cap keeps outermost maxDepth hops truncates inner",
+			raw:      nestedAct(20, labelsABC(20)),
+			maxDepth: 16,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 16)
+				assert.True(t, c.Truncated)
+				// dropped inner hops = 20 - 16 = 4
+				assert.Equal(t, 4, c.Omitted)
+				// The kept hops must be the OUTERMOST (C,B,A,...), not middle/inner.
+				assert.Equal(t, "C", c.Chain[0].Issuer)
+				// The 16th kept hop should be the 16th outermost label, NOT the
+				// innermost. labelsABC(20) => [C,B,A,Z,Y,X,W,V,U,T,S,R,Q,P,O,N,...]
+				// so index 15 (the 16th) is "N".
+				assert.Equal(t, "N", c.Chain[15].Issuer)
+			},
+		},
+		{
+			name: "act present but not a map returns error",
+			raw: map[string]any{
+				hopClaimSub: "x",
+				hopClaimAct: "not-a-map",
+			},
+			maxDepth:    DefaultMaxDelegationDepth,
+			wantErr:     true,
+			errContains: "act claim must be a JSON object",
+			wantErrIs:   ErrNestedActNotObject,
+		},
+		{
+			name: "extra claims retained in memory",
+			raw: map[string]any{
+				hopClaimSub:     testActorAlice,
+				extraClaimEmail: testAliceEmail,
+				"role":          testAdminRole,
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				extra := c.Chain[0].Extra()
+				require.NotNil(t, extra)
+				assert.Equal(t, testAliceEmail, extra[extraClaimEmail])
+				assert.Equal(t, testAdminRole, extra["role"])
+			},
+		},
+		{
+			name:     "maxDepth 0 uses default 16 no truncation at depth 3",
+			raw:      nestedAct(3, labelsABC(3)),
+			maxDepth: 0,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 3)
+				assert.False(t, c.Truncated)
+			},
+		},
+		{
+			name:     "negative maxDepth uses default 16 no truncation at depth 3",
+			raw:      nestedAct(3, labelsABC(3)),
+			maxDepth: -5,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 3)
+				assert.False(t, c.Truncated)
+			},
+		},
+		{
+			name:     "depth 1000 with maxDepth 16 truncates omitted 984 no panic",
+			raw:      nestedAct(1000, labelsABC(1000)),
+			maxDepth: 16,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 16)
+				assert.True(t, c.Truncated)
+				assert.Equal(t, 984, c.Omitted)
+				// outermost preserved
+				assert.Equal(t, "C", c.Chain[0].Issuer)
+			},
+		},
+		{
+			name:        "json.Number scalar returns ErrNotJSONObject",
+			raw:         json.Number("123"),
+			maxDepth:    DefaultMaxDelegationDepth,
+			wantErr:     true,
+			errContains: "json.Number",
+			wantErrIs:   ErrNotJSONObject,
+		},
+		{
+			name:     "depth one over cap Omits exactly 1 outermost preserved",
+			raw:      nestedAct(17, labelsABC(17)),
+			maxDepth: 16,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 16)
+				assert.True(t, c.Truncated, "must be truncated at depth 17 vs cap 16")
+				assert.Equal(t, 1, c.Omitted, "exactly one hop must be omitted")
+				// Chain[0] is the outermost actor, preserved.
+				assert.Equal(t, "C", c.Chain[0].Issuer)
+			},
+		},
+		{
+			name: "extra claims with rich types stored in Extra",
+			raw: map[string]any{
+				hopClaimSub: "x",
+				"extra_obj": map[string]any{"nested": "value"},
+				"extra_arr": []any{1, 2, 3},
+				"extra_num": float64(42),
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				extra := c.Chain[0].Extra()
+				require.NotNil(t, extra)
+
+				obj, ok := extra["extra_obj"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "value", obj["nested"])
+
+				arr, ok := extra["extra_arr"].([]any)
+				require.True(t, ok)
+				assert.Equal(t, []any{1, 2, 3}, arr)
+
+				num, ok := extra["extra_num"].(float64)
+				require.True(t, ok)
+				assert.Equal(t, float64(42), num)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c, err := ParseDelegationChain(tt.raw, tt.maxDepth)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(t, err, tt.wantErrIs)
+				}
+				assert.Nil(t, c)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, c)
+			}
+		})
+	}
+}
+
+func TestDelegatedActor_Extra(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns a copy mutation does not affect internal state", func(t *testing.T) {
+		t.Parallel()
+		a := DelegatedActor{
+			Issuer:  "i",
+			Subject: "s",
+			extra:   map[string]any{extraClaimEmail: testAliceEmail, "n": 42},
+		}
+		got := a.Extra()
+		require.Equal(t, testAliceEmail, got[extraClaimEmail])
+
+		// Mutate the returned copy; internal state must be unchanged.
+		got[extraClaimEmail] = "mutated"
+		got["newkey"] = "newval"
+		again := a.Extra()
+		assert.Equal(t, testAliceEmail, again[extraClaimEmail])
+		_, hasNew := again["newkey"]
+		assert.False(t, hasNew, "internal extra must not gain new keys")
+	})
+
+	t.Run("nil for zero value", func(t *testing.T) {
+		t.Parallel()
+		var a DelegatedActor
+		assert.Nil(t, a.Extra())
+	})
+}
+
+func TestDelegationChain_IsEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil chain is empty", func(t *testing.T) {
+		t.Parallel()
+		var c *DelegationChain
+		assert.True(t, c.IsEmpty())
+	})
+
+	t.Run("zero value is empty", func(t *testing.T) {
+		t.Parallel()
+		var c DelegationChain
+		assert.True(t, c.IsEmpty())
+	})
+
+	t.Run("one empty hop is not empty", func(t *testing.T) {
+		t.Parallel()
+		c := &DelegationChain{Chain: []DelegatedActor{{}}}
+		assert.False(t, c.IsEmpty())
+	})
+}
+
+func TestAuditEventWithDelegationChain(t *testing.T) {
+	t.Parallel()
+
+	chain := &DelegationChain{
+		Chain: []DelegatedActor{
+			{Issuer: "iss-1", Subject: "sub-1"},
+			{Issuer: "iss-2", Subject: "sub-2"},
+		},
+	}
+
+	t.Run("attach non-empty sets field", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{subjKeyUser: testActorAlice}, "svc")
+		result := event.WithDelegationChain(chain)
+		assert.Equal(t, event, result)
+		require.NotNil(t, event.DelegationChain)
+		assert.Equal(t, chain, event.DelegationChain)
+	})
+
+	t.Run("attach nil clears field", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+		event.WithDelegationChain(chain)
+		require.NotNil(t, event.DelegationChain)
+		event.WithDelegationChain(nil)
+		assert.Nil(t, event.DelegationChain)
+	})
+
+	t.Run("attach empty chain clears field", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+		event.WithDelegationChain(chain)
+		require.NotNil(t, event.DelegationChain)
+		event.WithDelegationChain(&DelegationChain{})
+		assert.Nil(t, event.DelegationChain)
+	})
+
+	t.Run("attach then nil clears field", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+		event.WithDelegationChain(chain)
+		event.WithDelegationChain(nil)
+		assert.Nil(t, event.DelegationChain)
+	})
+
+	t.Run("Subjects unchanged after attach no side effect", func(t *testing.T) {
+		t.Parallel()
+		subjects := map[string]string{subjKeyUser: testActorAlice, "role": testAdminRole}
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, subjects, "svc")
+		before := cloneStringMap(event.Subjects)
+		event.WithDelegationChain(chain)
+		assert.Equal(t, before, event.Subjects, "Subjects must not be modified by WithDelegationChain")
+		// deep-equal guard: ensure map is the same reference and contents
+		assert.Equal(t, subjects, event.Subjects)
+	})
+}
+
+func cloneStringMap(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func TestAuditEventLogTo_Delegation(t *testing.T) {
+	t.Parallel()
+
+	// Build a 3-hop chain with an extra (PII) claim on hop 0, then parse with
+	// maxDepth 2 so it truncates to 2 kept hops, Omitted=1.
+	raw := map[string]any{
+		hopClaimIss:     "outer-iss",
+		hopClaimSub:     "current-actor",
+		extraClaimEmail: "secret@example.com", // PII extra claim
+		hopClaimAct: map[string]any{
+			hopClaimIss: "mid-iss",
+			hopClaimSub: "mid-sub",
+			hopClaimAct: map[string]any{
+				hopClaimIss: "inner-iss",
+				hopClaimSub: "inner-sub",
+			},
+		},
+	}
+	chain, err := ParseDelegationChain(raw, 2)
+	require.NoError(t, err)
+	require.True(t, chain.Truncated)
+	assert.Equal(t, 1, chain.Omitted)
+	require.Len(t, chain.Chain, 2)
+
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(handler)
+
+	event := NewAuditEvent("mcp_tool_call", EventSource{Type: SourceTypeNetwork, Value: testSourceIP},
+		OutcomeSuccess, map[string]string{subjKeyUser: testActorAlice}, "svc")
+	event.WithDelegationChain(chain)
+
+	event.LogTo(context.Background(), logger, LevelAudit)
+
+	out := buf.String()
+	require.NotEmpty(t, out)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &entry))
+
+	delegation, ok := entry["delegation"].(map[string]any)
+	require.True(t, ok, "delegation group must be present")
+
+	hops, ok := delegation["hops"].(map[string]any)
+	require.True(t, ok, "hops must be a map")
+	assert.Len(t, hops, 2, "hops length must be 2 (truncated)")
+
+	hop0, ok := hops["hop_0"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "current-actor", hop0["sub"], "hop_0.sub must be the current actor")
+	assert.Equal(t, "outer-iss", hop0["iss"])
+
+	assert.Equal(t, true, delegation["truncated"])
+	assert.Equal(t, float64(1), delegation["omitted"])
+
+	// PII guard: the extra-claim key must NOT appear anywhere in the output.
+	assert.NotContains(t, out, "secret@example.com")
+	assert.NotContains(t, out, "\"email\"", "extra claims must not be serialized")
+}
+
+func TestAuditEventJSON_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	chain := &DelegationChain{
+		Chain: []DelegatedActor{
+			{Issuer: "iss-1", Subject: "sub-1", extra: map[string]any{extraClaimEmail: testAliceEmail}},
+			{Issuer: "iss-2", Subject: "sub-2"},
+		},
+		Truncated: true,
+		Omitted:   3,
+	}
+
+	event := NewAuditEvent("mcp_tool_call", EventSource{Type: SourceTypeNetwork, Value: testSourceIP},
+		OutcomeSuccess, map[string]string{subjKeyUser: testActorAlice}, "svc")
+	event.WithDelegationChain(chain)
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	var decoded AuditEvent
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	// Chain (iss/sub only) and Truncated/Omitted must round-trip.
+	require.NotNil(t, decoded.DelegationChain)
+	require.Len(t, decoded.DelegationChain.Chain, 2)
+	assert.Equal(t, "iss-1", decoded.DelegationChain.Chain[0].Issuer)
+	assert.Equal(t, "sub-1", decoded.DelegationChain.Chain[0].Subject)
+	assert.Equal(t, "iss-2", decoded.DelegationChain.Chain[1].Issuer)
+	assert.Equal(t, "sub-2", decoded.DelegationChain.Chain[1].Subject)
+	assert.True(t, decoded.DelegationChain.Truncated)
+	assert.Equal(t, 3, decoded.DelegationChain.Omitted)
+
+	// Extra must NOT round-trip (in-memory only).
+	assert.Nil(t, decoded.DelegationChain.Chain[0].Extra())
+}
+
+func TestAuditEventJSON_OmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil chain omits delegation key", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "delegation")
+	})
+
+	t.Run("empty chain omits delegation key", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+		event.WithDelegationChain(&DelegationChain{})
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "delegation")
+	})
+}

--- a/audit/delegation_test.go
+++ b/audit/delegation_test.go
@@ -447,7 +447,6 @@ func checkTopLevelMalformed(t *testing.T, c *DelegationChain) {
 	assert.Equal(t, MalformedReasonActNotObject, c.MalformedReason)
 	assert.False(t, c.Truncated)
 	assert.Equal(t, 0, c.Omitted)
-	assert.True(t, c.IsEmpty())
 	assert.False(t, c.IsZero(), "a malformed chain carries information and is not zero")
 }
 
@@ -480,34 +479,30 @@ func TestDelegatedActor_Extra(t *testing.T) {
 	})
 }
 
-func TestDelegationChain_IsEmptyIsZero(t *testing.T) {
+func TestDelegationChain_IsZero(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil chain is empty and zero", func(t *testing.T) {
+	t.Run("nil chain is zero", func(t *testing.T) {
 		t.Parallel()
 		var c *DelegationChain
-		assert.True(t, c.IsEmpty())
 		assert.True(t, c.IsZero())
 	})
 
-	t.Run("zero value is empty and zero", func(t *testing.T) {
+	t.Run("zero value is zero", func(t *testing.T) {
 		t.Parallel()
 		var c DelegationChain
-		assert.True(t, c.IsEmpty())
 		assert.True(t, c.IsZero())
 	})
 
-	t.Run("one empty hop is not empty and not zero", func(t *testing.T) {
+	t.Run("one empty hop is not zero", func(t *testing.T) {
 		t.Parallel()
 		c := &DelegationChain{Chain: []DelegatedActor{{}}}
-		assert.False(t, c.IsEmpty())
 		assert.False(t, c.IsZero())
 	})
 
-	t.Run("hopless malformed chain is empty but not zero", func(t *testing.T) {
+	t.Run("hopless malformed chain is not zero", func(t *testing.T) {
 		t.Parallel()
 		c := &DelegationChain{Chain: []DelegatedActor{}, Malformed: true}
-		assert.True(t, c.IsEmpty())
 		assert.False(t, c.IsZero())
 	})
 }
@@ -644,14 +639,22 @@ func TestAuditEventLogTo_Delegation(t *testing.T) {
 // TestAuditEventLogTo_SlogMatchesJSON pins the contract that the "delegation"
 // object in slog output is structurally equal to the "delegation" object in
 // json.Marshal(event) output, so consumers can use one parser for both wire
-// shapes.
+// shapes — and that no handler, including fmt-based ones, can render the
+// unexported extra claims.
 func TestAuditEventLogTo_SlogMatchesJSON(t *testing.T) {
 	t.Parallel()
 
+	// The outer hop carries a PII extra claim; the inner hop has no sub. The
+	// extra must reach no handler at all, and an absent sub must be omitted
+	// rather than emitted as "" so both wire shapes stay identical.
 	chain := ParseDelegationChain(map[string]any{
-		hopClaimIss: testIss1,
-		hopClaimSub: testSub1,
-		hopClaimAct: "broken", // exercises malformed + malformedReason too
+		hopClaimIss:     testIss1,
+		hopClaimSub:     testSub1,
+		extraClaimEmail: testAliceEmail,
+		hopClaimAct: map[string]any{
+			hopClaimIss: testHopInner,
+			hopClaimAct: "broken", // exercises malformed + malformedReason too
+		},
 	}, 0)
 
 	event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
@@ -661,17 +664,28 @@ func TestAuditEventLogTo_SlogMatchesJSON(t *testing.T) {
 	require.NoError(t, err)
 	var fromJSON map[string]any
 	require.NoError(t, json.Unmarshal(data, &fromJSON))
+	require.Contains(t, fromJSON, "delegation")
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	event.LogTo(context.Background(), logger, LevelAudit)
 	var fromSlog map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &fromSlog))
-
-	require.Contains(t, fromJSON, "delegation")
 	require.Contains(t, fromSlog, "delegation")
 	assert.Equal(t, fromJSON["delegation"], fromSlog["delegation"],
 		"slog and JSON delegation shapes must be identical")
+
+	// Every handler, not only JSONHandler: a fmt-based handler must not be able
+	// to render the unexported extra claims, and must keep the chain structured.
+	var text bytes.Buffer
+	event.LogTo(context.Background(),
+		slog.New(slog.NewTextHandler(&text, &slog.HandlerOptions{Level: slog.LevelDebug})), LevelAudit)
+	assert.NotContains(t, text.String(), testAliceEmail,
+		"extra claim values must not reach a text handler")
+	assert.NotContains(t, text.String(), extraClaimEmail,
+		"extra claim keys must not reach a text handler")
+	assert.Contains(t, text.String(), "delegation.chain=",
+		"the chain must stay structured in text output")
 }
 
 func TestAuditEventJSON_RoundTrip(t *testing.T) {

--- a/audit/delegation_test.go
+++ b/audit/delegation_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -448,6 +449,40 @@ func checkTopLevelMalformed(t *testing.T, c *DelegationChain) {
 	assert.False(t, c.Truncated)
 	assert.Equal(t, 0, c.Omitted)
 	assert.False(t, c.IsZero(), "a malformed chain carries information and is not zero")
+}
+
+// TestDelegatedActor_FmtCannotLeakExtra pins the fmt-side PII door: rendering
+// a hop, a chain value, or a chain pointer with %v/%+v must never reach the
+// unexported extra claims (fmt consults Stringer, not slog.LogValuer).
+func TestDelegatedActor_FmtCannotLeakExtra(t *testing.T) {
+	t.Parallel()
+
+	chain := ParseDelegationChain(map[string]any{
+		hopClaimSub:     testSub1,
+		extraClaimEmail: testAliceEmail,
+	}, 0)
+	require.NotNil(t, chain.Chain[0].Extra(), "fixture must carry an extra claim")
+
+	for name, rendered := range map[string]string{
+		"bare hop %+v":          fmt.Sprintf("%+v", chain.Chain[0]),
+		"dereferenced chain %v": fmt.Sprintf("%v", *chain),
+		"chain pointer %+v":     fmt.Sprintf("%+v", chain),
+	} {
+		assert.NotContains(t, rendered, testAliceEmail, "%s must not leak extra values", name)
+		assert.NotContains(t, rendered, extraClaimEmail, "%s must not leak extra keys", name)
+		assert.Contains(t, rendered, testSub1, "%s must still render the subject", name)
+	}
+}
+
+// TestDelegationChain_LogValueNilSafe pins that a nil chain resolves to an
+// empty group rather than a recovered-panic stack trace in the record.
+func TestDelegationChain_LogValueNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger.LogAttrs(context.Background(), LevelAudit, "e", slog.Any("d", (*DelegationChain)(nil)))
+	assert.NotContains(t, buf.String(), "panicked", "nil chain must not render a recovered panic")
 }
 
 func TestDelegatedActor_Extra(t *testing.T) {

--- a/audit/delegation_test.go
+++ b/audit/delegation_test.go
@@ -17,11 +17,19 @@ import (
 // Test-local constants to satisfy goconst across repeated use in fixtures.
 const (
 	testAliceEmail  = "alice@example.com"
+	testHopOuter    = "outer"
+	testHopInner    = "inner"
+	testIss1        = "iss-1"
+	testSub1        = "sub-1"
 	testAdminRole   = "admin"
 	testSourceIP    = "10.0.0.1"
 	testActorAlice  = "alice"
 	extraClaimEmail = "email"
 )
+
+// mapClaims mimics jwt.MapClaims: a named map type that does not satisfy a
+// direct .(map[string]any) type assertion.
+type mapClaims map[string]any
 
 // nestedAct builds a deeply nested act chain map of the given depth where
 // each hop has iss=<label>. The outermost hop is labeled with labels[0].
@@ -58,57 +66,52 @@ func TestParseDelegationChain(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		raw         any
-		maxDepth    int
-		wantErr     bool
-		errContains string
-		wantErrIs   error
-		check       func(t *testing.T, c *DelegationChain)
+		name     string
+		raw      any
+		maxDepth int
+		check    func(t *testing.T, c *DelegationChain)
 	}{
 		{
-			name:     "nil input returns empty non-nil chain",
+			name:     "nil input returns zero non-nil chain",
 			raw:      nil,
 			maxDepth: DefaultMaxDelegationDepth,
 			check: func(t *testing.T, c *DelegationChain) {
 				t.Helper()
-				require.NotNil(t, c)
-				assert.True(t, c.IsEmpty(), "nil input should yield empty chain")
-				assert.False(t, c.Truncated)
-				assert.Equal(t, 0, c.Omitted)
+				assert.True(t, c.IsZero(), "nil input should yield zero chain")
+				assert.NotNil(t, c.Chain, "Chain must be allocated, never nil")
+				assert.False(t, c.Malformed)
+				assert.Empty(t, c.MalformedReason)
 			},
 		},
 		{
-			name:        "string scalar returns error naming kind",
-			raw:         "not-an-object",
-			maxDepth:    DefaultMaxDelegationDepth,
-			wantErr:     true,
-			errContains: "string",
-			wantErrIs:   ErrNotJSONObject,
+			name:     "string scalar flags act_not_object",
+			raw:      "not-an-object",
+			maxDepth: DefaultMaxDelegationDepth,
+			check:    checkTopLevelMalformed,
 		},
 		{
-			name:        "float64 scalar returns error naming kind",
-			raw:         float64(3.14),
-			maxDepth:    DefaultMaxDelegationDepth,
-			wantErr:     true,
-			errContains: "float64",
-			wantErrIs:   ErrNotJSONObject,
+			name:     "float64 scalar flags act_not_object",
+			raw:      float64(3.14),
+			maxDepth: DefaultMaxDelegationDepth,
+			check:    checkTopLevelMalformed,
 		},
 		{
-			name:        "bool scalar returns error naming kind",
-			raw:         true,
-			maxDepth:    DefaultMaxDelegationDepth,
-			wantErr:     true,
-			errContains: "bool",
-			wantErrIs:   ErrNotJSONObject,
+			name:     "bool scalar flags act_not_object",
+			raw:      true,
+			maxDepth: DefaultMaxDelegationDepth,
+			check:    checkTopLevelMalformed,
 		},
 		{
-			name:        "slice returns error naming kind",
-			raw:         []any{"x"},
-			maxDepth:    DefaultMaxDelegationDepth,
-			wantErr:     true,
-			errContains: "[]interface",
-			wantErrIs:   ErrNotJSONObject,
+			name:     "slice flags act_not_object",
+			raw:      []any{"x"},
+			maxDepth: DefaultMaxDelegationDepth,
+			check:    checkTopLevelMalformed,
+		},
+		{
+			name:     "json.Number scalar flags act_not_object",
+			raw:      json.Number("123"),
+			maxDepth: DefaultMaxDelegationDepth,
+			check:    checkTopLevelMalformed,
 		},
 		{
 			name:     "empty map yields one hop with empty subject/issuer",
@@ -116,11 +119,11 @@ func TestParseDelegationChain(t *testing.T) {
 			maxDepth: DefaultMaxDelegationDepth,
 			check: func(t *testing.T, c *DelegationChain) {
 				t.Helper()
-				require.NotNil(t, c)
 				require.Len(t, c.Chain, 1)
 				assert.Empty(t, c.Chain[0].Subject)
 				assert.Empty(t, c.Chain[0].Issuer)
 				assert.False(t, c.Truncated)
+				assert.False(t, c.Malformed)
 			},
 		},
 		{
@@ -132,6 +135,7 @@ func TestParseDelegationChain(t *testing.T) {
 				require.Len(t, c.Chain, 1)
 				assert.Equal(t, testActorAlice, c.Chain[0].Subject)
 				assert.Empty(t, c.Chain[0].Issuer)
+				assert.False(t, c.Malformed)
 			},
 		},
 		{
@@ -148,10 +152,10 @@ func TestParseDelegationChain(t *testing.T) {
 		{
 			name: "one hop with nested act yields two entries outermost-first",
 			raw: map[string]any{
-				hopClaimIss: "outer",
+				hopClaimIss: testHopOuter,
 				hopClaimSub: "outer-sub",
 				hopClaimAct: map[string]any{
-					hopClaimIss: "inner",
+					hopClaimIss: testHopInner,
 					hopClaimSub: "inner-sub",
 				},
 			},
@@ -159,8 +163,8 @@ func TestParseDelegationChain(t *testing.T) {
 			check: func(t *testing.T, c *DelegationChain) {
 				t.Helper()
 				require.Len(t, c.Chain, 2)
-				assert.Equal(t, "outer", c.Chain[0].Issuer)
-				assert.Equal(t, "inner", c.Chain[1].Issuer)
+				assert.Equal(t, testHopOuter, c.Chain[0].Issuer)
+				assert.Equal(t, testHopInner, c.Chain[1].Issuer)
 				assert.False(t, c.Truncated)
 				assert.Equal(t, 0, c.Omitted)
 			},
@@ -206,54 +210,20 @@ func TestParseDelegationChain(t *testing.T) {
 				// innermost. labelsABC(20) => [C,B,A,Z,Y,X,W,V,U,T,S,R,Q,P,O,N,...]
 				// so index 15 (the 16th) is "N".
 				assert.Equal(t, "N", c.Chain[15].Issuer)
+				assert.False(t, c.Malformed, "well-formed truncated chain must not be malformed")
 			},
 		},
 		{
-			name: "act present but not a map returns error",
-			raw: map[string]any{
-				hopClaimSub: "x",
-				hopClaimAct: "not-a-map",
-			},
-			maxDepth:    DefaultMaxDelegationDepth,
-			wantErr:     true,
-			errContains: "act claim must be a JSON object",
-			wantErrIs:   ErrNestedActNotObject,
-		},
-		{
-			name: "extra claims retained in memory",
-			raw: map[string]any{
-				hopClaimSub:     testActorAlice,
-				extraClaimEmail: testAliceEmail,
-				"role":          testAdminRole,
-			},
-			maxDepth: DefaultMaxDelegationDepth,
+			name:     "depth one over cap Omits exactly 1 outermost preserved",
+			raw:      nestedAct(17, labelsABC(17)),
+			maxDepth: 16,
 			check: func(t *testing.T, c *DelegationChain) {
 				t.Helper()
-				require.Len(t, c.Chain, 1)
-				extra := c.Chain[0].Extra()
-				require.NotNil(t, extra)
-				assert.Equal(t, testAliceEmail, extra[extraClaimEmail])
-				assert.Equal(t, testAdminRole, extra["role"])
-			},
-		},
-		{
-			name:     "maxDepth 0 uses default 16 no truncation at depth 3",
-			raw:      nestedAct(3, labelsABC(3)),
-			maxDepth: 0,
-			check: func(t *testing.T, c *DelegationChain) {
-				t.Helper()
-				require.Len(t, c.Chain, 3)
-				assert.False(t, c.Truncated)
-			},
-		},
-		{
-			name:     "negative maxDepth uses default 16 no truncation at depth 3",
-			raw:      nestedAct(3, labelsABC(3)),
-			maxDepth: -5,
-			check: func(t *testing.T, c *DelegationChain) {
-				t.Helper()
-				require.Len(t, c.Chain, 3)
-				assert.False(t, c.Truncated)
+				require.Len(t, c.Chain, 16)
+				assert.True(t, c.Truncated, "must be truncated at depth 17 vs cap 16")
+				assert.Equal(t, 1, c.Omitted, "exactly one hop must be omitted")
+				// Chain[0] is the outermost actor, preserved.
+				assert.Equal(t, "C", c.Chain[0].Issuer)
 			},
 		},
 		{
@@ -270,24 +240,140 @@ func TestParseDelegationChain(t *testing.T) {
 			},
 		},
 		{
-			name:        "json.Number scalar returns ErrNotJSONObject",
-			raw:         json.Number("123"),
-			maxDepth:    DefaultMaxDelegationDepth,
-			wantErr:     true,
-			errContains: "json.Number",
-			wantErrIs:   ErrNotJSONObject,
-		},
-		{
-			name:     "depth one over cap Omits exactly 1 outermost preserved",
-			raw:      nestedAct(17, labelsABC(17)),
-			maxDepth: 16,
+			name: "nested act not a map keeps parsed hops and flags malformed",
+			raw: map[string]any{
+				hopClaimSub: "x",
+				hopClaimAct: "not-a-map",
+			},
+			maxDepth: DefaultMaxDelegationDepth,
 			check: func(t *testing.T, c *DelegationChain) {
 				t.Helper()
-				require.Len(t, c.Chain, 16)
-				assert.True(t, c.Truncated, "must be truncated at depth 17 vs cap 16")
-				assert.Equal(t, 1, c.Omitted, "exactly one hop must be omitted")
-				// Chain[0] is the outermost actor, preserved.
-				assert.Equal(t, "C", c.Chain[0].Issuer)
+				require.Len(t, c.Chain, 1, "the outer hop must be preserved")
+				assert.Equal(t, "x", c.Chain[0].Subject)
+				assert.True(t, c.Malformed)
+				assert.Equal(t, MalformedReasonNestedActNotObject, c.MalformedReason)
+				assert.False(t, c.Truncated)
+				assert.Equal(t, 0, c.Omitted)
+			},
+		},
+		{
+			name: "explicit null act ends the chain without malformation",
+			raw: map[string]any{
+				hopClaimSub: "x",
+				hopClaimAct: nil,
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				assert.False(t, c.Malformed, "JSON null act asserts no delegation, like absence")
+			},
+		},
+		{
+			name: "non-string sub flags malformed and retains raw value in extra",
+			raw: map[string]any{
+				hopClaimSub: float64(123),
+				hopClaimIss: "issuer-1",
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				assert.Empty(t, c.Chain[0].Subject, "non-string sub must not be coerced")
+				assert.Equal(t, "issuer-1", c.Chain[0].Issuer)
+				assert.True(t, c.Malformed)
+				assert.Equal(t, MalformedReasonSubNotString, c.MalformedReason)
+				extra := c.Chain[0].Extra()
+				require.NotNil(t, extra, "raw non-string sub must stay inspectable in memory")
+				assert.Equal(t, float64(123), extra[hopClaimSub])
+			},
+		},
+		{
+			name: "non-string iss flags malformed and retains raw value in extra",
+			raw: map[string]any{
+				hopClaimIss: []any{"not", "a", "string"},
+				hopClaimSub: "subject-1",
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				assert.Empty(t, c.Chain[0].Issuer)
+				assert.Equal(t, "subject-1", c.Chain[0].Subject)
+				assert.True(t, c.Malformed)
+				assert.Equal(t, MalformedReasonIssNotString, c.MalformedReason)
+				extra := c.Chain[0].Extra()
+				require.NotNil(t, extra)
+				assert.Equal(t, []any{"not", "a", "string"}, extra[hopClaimIss])
+			},
+		},
+		{
+			name: "first malformed reason wins",
+			raw: map[string]any{
+				hopClaimSub: float64(1), // sub_not_string, encountered first
+				hopClaimAct: "scalar",   // nested_act_not_object, encountered second
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				assert.True(t, c.Malformed)
+				assert.Equal(t, MalformedReasonSubNotString, c.MalformedReason)
+			},
+		},
+		{
+			name: "malformed node past the cap flags malformed without counting it",
+			raw: map[string]any{
+				hopClaimSub: testHopOuter,
+				hopClaimAct: map[string]any{
+					hopClaimSub: "mid",
+					hopClaimAct: map[string]any{
+						hopClaimSub: testHopInner,
+						hopClaimAct: "scalar-tail",
+					},
+				},
+			},
+			maxDepth: 2,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 2)
+				assert.True(t, c.Truncated)
+				assert.Equal(t, 1, c.Omitted, "only the well-formed inner hop counts as omitted")
+				assert.True(t, c.Malformed)
+				assert.Equal(t, MalformedReasonNestedActNotObject, c.MalformedReason)
+			},
+		},
+		{
+			name: "named map type is accepted at top level and nested",
+			raw: mapClaims{
+				hopClaimSub: testHopOuter,
+				hopClaimAct: mapClaims{
+					hopClaimSub: testHopInner,
+				},
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 2, "jwt.MapClaims-shaped input must parse, not vanish")
+				assert.Equal(t, testHopOuter, c.Chain[0].Subject)
+				assert.Equal(t, testHopInner, c.Chain[1].Subject)
+				assert.False(t, c.Malformed)
+			},
+		},
+		{
+			name: "extra claims retained in memory",
+			raw: map[string]any{
+				hopClaimSub:     testActorAlice,
+				extraClaimEmail: testAliceEmail,
+				"role":          testAdminRole,
+			},
+			maxDepth: DefaultMaxDelegationDepth,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 1)
+				extra := c.Chain[0].Extra()
+				require.NotNil(t, extra)
+				assert.Equal(t, testAliceEmail, extra[extraClaimEmail])
+				assert.Equal(t, testAdminRole, extra["role"])
 			},
 		},
 		{
@@ -318,29 +404,51 @@ func TestParseDelegationChain(t *testing.T) {
 				assert.Equal(t, float64(42), num)
 			},
 		},
+		{
+			name:     "maxDepth 0 uses default 16 no truncation at depth 3",
+			raw:      nestedAct(3, labelsABC(3)),
+			maxDepth: 0,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 3)
+				assert.False(t, c.Truncated)
+			},
+		},
+		{
+			name:     "negative maxDepth uses default 16 no truncation at depth 3",
+			raw:      nestedAct(3, labelsABC(3)),
+			maxDepth: -5,
+			check: func(t *testing.T, c *DelegationChain) {
+				t.Helper()
+				require.Len(t, c.Chain, 3)
+				assert.False(t, c.Truncated)
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			c, err := ParseDelegationChain(tt.raw, tt.maxDepth)
-			if tt.wantErr {
-				require.Error(t, err)
-				if tt.errContains != "" {
-					assert.Contains(t, err.Error(), tt.errContains)
-				}
-				if tt.wantErrIs != nil {
-					assert.ErrorIs(t, err, tt.wantErrIs)
-				}
-				assert.Nil(t, c)
-				return
-			}
-			require.NoError(t, err)
-			if tt.check != nil {
-				tt.check(t, c)
-			}
+			c := ParseDelegationChain(tt.raw, tt.maxDepth)
+			require.NotNil(t, c, "ParseDelegationChain never returns nil")
+			require.NotNil(t, c.Chain, "Chain must always be allocated")
+			tt.check(t, c)
 		})
 	}
+}
+
+// checkTopLevelMalformed is the shared assertion for non-object top-level
+// input: no hops, Malformed=true with act_not_object, no truncation.
+func checkTopLevelMalformed(t *testing.T, c *DelegationChain) {
+	t.Helper()
+	assert.Empty(t, c.Chain)
+	assert.NotNil(t, c.Chain, "even a malformed chain must serialize chain as [], not null")
+	assert.True(t, c.Malformed)
+	assert.Equal(t, MalformedReasonActNotObject, c.MalformedReason)
+	assert.False(t, c.Truncated)
+	assert.Equal(t, 0, c.Omitted)
+	assert.True(t, c.IsEmpty())
+	assert.False(t, c.IsZero(), "a malformed chain carries information and is not zero")
 }
 
 func TestDelegatedActor_Extra(t *testing.T) {
@@ -372,25 +480,35 @@ func TestDelegatedActor_Extra(t *testing.T) {
 	})
 }
 
-func TestDelegationChain_IsEmpty(t *testing.T) {
+func TestDelegationChain_IsEmptyIsZero(t *testing.T) {
 	t.Parallel()
 
-	t.Run("nil chain is empty", func(t *testing.T) {
+	t.Run("nil chain is empty and zero", func(t *testing.T) {
 		t.Parallel()
 		var c *DelegationChain
 		assert.True(t, c.IsEmpty())
+		assert.True(t, c.IsZero())
 	})
 
-	t.Run("zero value is empty", func(t *testing.T) {
+	t.Run("zero value is empty and zero", func(t *testing.T) {
 		t.Parallel()
 		var c DelegationChain
 		assert.True(t, c.IsEmpty())
+		assert.True(t, c.IsZero())
 	})
 
-	t.Run("one empty hop is not empty", func(t *testing.T) {
+	t.Run("one empty hop is not empty and not zero", func(t *testing.T) {
 		t.Parallel()
 		c := &DelegationChain{Chain: []DelegatedActor{{}}}
 		assert.False(t, c.IsEmpty())
+		assert.False(t, c.IsZero())
+	})
+
+	t.Run("hopless malformed chain is empty but not zero", func(t *testing.T) {
+		t.Parallel()
+		c := &DelegationChain{Chain: []DelegatedActor{}, Malformed: true}
+		assert.True(t, c.IsEmpty())
+		assert.False(t, c.IsZero())
 	})
 }
 
@@ -399,7 +517,7 @@ func TestAuditEventWithDelegationChain(t *testing.T) {
 
 	chain := &DelegationChain{
 		Chain: []DelegatedActor{
-			{Issuer: "iss-1", Subject: "sub-1"},
+			{Issuer: testIss1, Subject: testSub1},
 			{Issuer: "iss-2", Subject: "sub-2"},
 		},
 	}
@@ -422,7 +540,7 @@ func TestAuditEventWithDelegationChain(t *testing.T) {
 		assert.Nil(t, event.DelegationChain)
 	})
 
-	t.Run("attach empty chain clears field", func(t *testing.T) {
+	t.Run("attach zero chain clears field", func(t *testing.T) {
 		t.Parallel()
 		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
 		event.WithDelegationChain(chain)
@@ -431,12 +549,14 @@ func TestAuditEventWithDelegationChain(t *testing.T) {
 		assert.Nil(t, event.DelegationChain)
 	})
 
-	t.Run("attach then nil clears field", func(t *testing.T) {
+	t.Run("attach hopless malformed chain is kept", func(t *testing.T) {
 		t.Parallel()
 		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
-		event.WithDelegationChain(chain)
-		event.WithDelegationChain(nil)
-		assert.Nil(t, event.DelegationChain)
+		malformed := ParseDelegationChain("not-an-object", 0)
+		event.WithDelegationChain(malformed)
+		require.NotNil(t, event.DelegationChain,
+			"a malformed delegation assertion is audit-relevant and must not be dropped")
+		assert.True(t, event.DelegationChain.Malformed)
 	})
 
 	t.Run("Subjects unchanged after attach no side effect", func(t *testing.T) {
@@ -477,8 +597,7 @@ func TestAuditEventLogTo_Delegation(t *testing.T) {
 			},
 		},
 	}
-	chain, err := ParseDelegationChain(raw, 2)
-	require.NoError(t, err)
+	chain := ParseDelegationChain(raw, 2)
 	require.True(t, chain.Truncated)
 	assert.Equal(t, 1, chain.Omitted)
 	require.Len(t, chain.Chain, 2)
@@ -500,23 +619,59 @@ func TestAuditEventLogTo_Delegation(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &entry))
 
 	delegation, ok := entry["delegation"].(map[string]any)
-	require.True(t, ok, "delegation group must be present")
+	require.True(t, ok, "delegation object must be present")
 
-	hops, ok := delegation["hops"].(map[string]any)
-	require.True(t, ok, "hops must be a map")
-	assert.Len(t, hops, 2, "hops length must be 2 (truncated)")
+	// The slog shape must be structurally identical to the event's JSON
+	// marshaling: a "chain" ARRAY of {iss,sub} hops (not hop_N-keyed groups).
+	hops, ok := delegation["chain"].([]any)
+	require.True(t, ok, "chain must be a JSON array")
+	require.Len(t, hops, 2, "chain length must be 2 (truncated)")
 
-	hop0, ok := hops["hop_0"].(map[string]any)
+	hop0, ok := hops[0].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "current-actor", hop0["sub"], "hop_0.sub must be the current actor")
+	assert.Equal(t, "current-actor", hop0["sub"], "chain[0].sub must be the current actor")
 	assert.Equal(t, "outer-iss", hop0["iss"])
 
 	assert.Equal(t, true, delegation["truncated"])
 	assert.Equal(t, float64(1), delegation["omitted"])
+	assert.Equal(t, false, delegation["malformed"])
 
 	// PII guard: the extra-claim key must NOT appear anywhere in the output.
 	assert.NotContains(t, out, "secret@example.com")
 	assert.NotContains(t, out, "\"email\"", "extra claims must not be serialized")
+}
+
+// TestAuditEventLogTo_SlogMatchesJSON pins the contract that the "delegation"
+// object in slog output is structurally equal to the "delegation" object in
+// json.Marshal(event) output, so consumers can use one parser for both wire
+// shapes.
+func TestAuditEventLogTo_SlogMatchesJSON(t *testing.T) {
+	t.Parallel()
+
+	chain := ParseDelegationChain(map[string]any{
+		hopClaimIss: testIss1,
+		hopClaimSub: testSub1,
+		hopClaimAct: "broken", // exercises malformed + malformedReason too
+	}, 0)
+
+	event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+	event.WithDelegationChain(chain)
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	var fromJSON map[string]any
+	require.NoError(t, json.Unmarshal(data, &fromJSON))
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	event.LogTo(context.Background(), logger, LevelAudit)
+	var fromSlog map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &fromSlog))
+
+	require.Contains(t, fromJSON, "delegation")
+	require.Contains(t, fromSlog, "delegation")
+	assert.Equal(t, fromJSON["delegation"], fromSlog["delegation"],
+		"slog and JSON delegation shapes must be identical")
 }
 
 func TestAuditEventJSON_RoundTrip(t *testing.T) {
@@ -524,11 +679,13 @@ func TestAuditEventJSON_RoundTrip(t *testing.T) {
 
 	chain := &DelegationChain{
 		Chain: []DelegatedActor{
-			{Issuer: "iss-1", Subject: "sub-1", extra: map[string]any{extraClaimEmail: testAliceEmail}},
+			{Issuer: testIss1, Subject: testSub1, extra: map[string]any{extraClaimEmail: testAliceEmail}},
 			{Issuer: "iss-2", Subject: "sub-2"},
 		},
-		Truncated: true,
-		Omitted:   3,
+		Truncated:       true,
+		Omitted:         3,
+		Malformed:       true,
+		MalformedReason: MalformedReasonNestedActNotObject,
 	}
 
 	event := NewAuditEvent("mcp_tool_call", EventSource{Type: SourceTypeNetwork, Value: testSourceIP},
@@ -541,18 +698,73 @@ func TestAuditEventJSON_RoundTrip(t *testing.T) {
 	var decoded AuditEvent
 	require.NoError(t, json.Unmarshal(data, &decoded))
 
-	// Chain (iss/sub only) and Truncated/Omitted must round-trip.
+	// Chain (iss/sub only) and Truncated/Omitted/Malformed must round-trip.
 	require.NotNil(t, decoded.DelegationChain)
 	require.Len(t, decoded.DelegationChain.Chain, 2)
-	assert.Equal(t, "iss-1", decoded.DelegationChain.Chain[0].Issuer)
-	assert.Equal(t, "sub-1", decoded.DelegationChain.Chain[0].Subject)
+	assert.Equal(t, testIss1, decoded.DelegationChain.Chain[0].Issuer)
+	assert.Equal(t, testSub1, decoded.DelegationChain.Chain[0].Subject)
 	assert.Equal(t, "iss-2", decoded.DelegationChain.Chain[1].Issuer)
 	assert.Equal(t, "sub-2", decoded.DelegationChain.Chain[1].Subject)
 	assert.True(t, decoded.DelegationChain.Truncated)
 	assert.Equal(t, 3, decoded.DelegationChain.Omitted)
+	assert.True(t, decoded.DelegationChain.Malformed)
+	assert.Equal(t, MalformedReasonNestedActNotObject, decoded.DelegationChain.MalformedReason)
 
 	// Extra must NOT round-trip (in-memory only).
 	assert.Nil(t, decoded.DelegationChain.Chain[0].Extra())
+}
+
+// TestDelegationChainJSON_WireKeys asserts the EMITTED JSON key names, not Go
+// struct fields, so a tag rename cannot slip through with a green suite.
+func TestDelegationChainJSON_WireKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("well-formed chain emits exactly the contracted keys", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+		event.WithDelegationChain(&DelegationChain{
+			Chain: []DelegatedActor{{Issuer: testIss1, Subject: testSub1}},
+		})
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &raw))
+		require.Contains(t, raw, "delegation")
+
+		var delegation map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(raw["delegation"], &delegation))
+		assert.ElementsMatch(t,
+			[]string{"chain", "truncated", "omitted", "malformed"},
+			keysOf(delegation),
+			"delegation wire keys are a contract; malformedReason is omitempty")
+
+		var hops []map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(delegation["chain"], &hops))
+		require.Len(t, hops, 1)
+		assert.ElementsMatch(t, []string{"iss", "sub"}, keysOf(hops[0]),
+			"hop wire keys are a contract")
+	})
+
+	t.Run("hopless malformed chain emits chain as empty array not null", func(t *testing.T) {
+		t.Parallel()
+		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
+		event.WithDelegationChain(ParseDelegationChain(float64(1), 0))
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"chain":[]`,
+			"a nil slice would marshal to null and break array-iterating consumers")
+		assert.Contains(t, string(data), `"malformed":true`)
+		assert.Contains(t, string(data), `"malformedReason":"act_not_object"`)
+	})
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestAuditEventJSON_OmitEmpty(t *testing.T) {
@@ -566,7 +778,7 @@ func TestAuditEventJSON_OmitEmpty(t *testing.T) {
 		assert.NotContains(t, string(data), "delegation")
 	})
 
-	t.Run("empty chain omits delegation key", func(t *testing.T) {
+	t.Run("zero chain omits delegation key", func(t *testing.T) {
 		t.Parallel()
 		event := NewAuditEvent("t", EventSource{}, OutcomeSuccess, map[string]string{}, "svc")
 		event.WithDelegationChain(&DelegationChain{})

--- a/audit/doc.go
+++ b/audit/doc.go
@@ -44,8 +44,9 @@ chain is additive to the flat [AuditEvent.Subjects] map; Subjects remains the
 backward-compatible identity map and is not modified by setting a chain.
 
 Parse raw `act` claims with [ParseDelegationChain], which applies a defensive
-depth cap ([DefaultMaxDelegationDepth], overridable via maxDepth) to bound
-work on attacker-influenceable input, and reports explicit truncation
+depth cap ([DefaultMaxDelegationDepth], overridable via maxDepth) to bound the
+size of the retained chain and of the emitted record — not parsing work, since
+the caller has already decoded the claim — and reports explicit truncation
 (Truncated/Omitted are never silently omitted). Per-hop identity is the issuer
 (iss) and subject (sub) pair only: (iss, sub) is the only stable, unique actor
 identifier (OpenID Connect Core §5.7), and RFC 8693 §6 calls for data

--- a/audit/doc.go
+++ b/audit/doc.go
@@ -45,17 +45,30 @@ backward-compatible identity map and is not modified by setting a chain.
 
 Parse raw `act` claims with [ParseDelegationChain], which applies a defensive
 depth cap ([DefaultMaxDelegationDepth], overridable via maxDepth) to bound
-recursion on attacker-influenceable input, and reports explicit truncation
+work on attacker-influenceable input, and reports explicit truncation
 (Truncated/Omitted are never silently omitted). Per-hop identity is the issuer
-(iss) and subject (sub) pair only, as specified by RFC 8693 §6. Any extra
-claims present on a hop are retained in memory for inspection via
-[DelegatedActor.Extra] but are never serialized or logged, to avoid leaking
-Personally Identifiable Information.
+(iss) and subject (sub) pair only: (iss, sub) is the only stable, unique actor
+identifier (OpenID Connect Core §5.7), and RFC 8693 §6 calls for data
+minimization. Any extra claims present on a hop are retained in memory for
+inspection via [DelegatedActor.Extra] but are never serialized or logged, to
+avoid leaking Personally Identifiable Information.
 
 The chain is ordered outermost-first: Chain[0] is the current actor and the
-last entry is the least recent (original) actor. Only the top-level event
-claims and Chain[0] should drive access-control decisions; prior hops are
-informational only.
+last entry is the least recent (earliest) actor. The delegating end user is
+not part of the chain — it is the token's top-level sub, recorded in Subjects.
+Only the top-level event claims and Chain[0] should drive access-control
+decisions; prior hops are informational only (RFC 8693 §4.1) and exist for
+audit.
+
+Parsing never fails: an audit record must be producible for exactly the
+tokens that violate expectations, since a malformed delegation assertion from
+a signature-validated token is itself security-relevant (it indicates an
+issuer bug or tampering), and dropping the record would let malformed input
+suppress audit (CWE-223, CWE-778). Non-conformant input is recorded on the
+chain via Malformed and a low-cardinality MalformedReason, with all hops that
+parsed successfully preserved. Strict rejection of malformed `act` claims
+belongs on the token-issuance path, not in the audit sink; consumers that
+alert can key on the malformed field.
 
 # Logging
 

--- a/audit/doc.go
+++ b/audit/doc.go
@@ -26,15 +26,36 @@ Each audit event records:
 Events support a fluent builder pattern for optional fields:
 
 	event := audit.NewAuditEvent(
-		audit.EventTypeMCPToolCall,
+		"mcp_tool_call",
 		audit.EventSource{Type: audit.SourceTypeNetwork, Value: "10.0.0.1"},
 		audit.OutcomeSuccess,
-		map[string]string{audit.SubjectKeyUser: "alice"},
+		map[string]string{"user": "alice"},
 		"my-service",
 	).WithTarget(map[string]string{
-		audit.TargetKeyType: audit.TargetTypeTool,
-		audit.TargetKeyName: "calculator",
+		"type": "tool",
+		"name": "calculator",
 	})
+
+# Delegation Chains
+
+When an actor acted on behalf of another actor (RFC 8693 `act` claim), attach
+a [DelegationChain] to the event via [AuditEvent.WithDelegationChain]. The
+chain is additive to the flat [AuditEvent.Subjects] map; Subjects remains the
+backward-compatible identity map and is not modified by setting a chain.
+
+Parse raw `act` claims with [ParseDelegationChain], which applies a defensive
+depth cap ([DefaultMaxDelegationDepth], overridable via maxDepth) to bound
+recursion on attacker-influenceable input, and reports explicit truncation
+(Truncated/Omitted are never silently omitted). Per-hop identity is the issuer
+(iss) and subject (sub) pair only, as specified by RFC 8693 §6. Any extra
+claims present on a hop are retained in memory for inspection via
+[DelegatedActor.Extra] but are never serialized or logged, to avoid leaking
+Personally Identifiable Information.
+
+The chain is ordered outermost-first: Chain[0] is the current actor and the
+last entry is the least recent (original) actor. Only the top-level event
+claims and Chain[0] should drive access-control decisions; prior hops are
+informational only.
 
 # Logging
 

--- a/audit/event.go
+++ b/audit/event.go
@@ -6,7 +6,6 @@ package audit
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -61,7 +60,8 @@ type AuditEvent struct {
 	Data *json.RawMessage `json:"data,omitempty"`
 	// DelegationChain holds the RFC 8693 `act` delegation chain when the event's
 	// actor acted on behalf of a prior actor. Additive to Subjects; Subjects
-	// remains the flat backward-compatible identity map. Omitted when empty.
+	// remains the flat backward-compatible identity map. Omitted when zero
+	// (no hops, no truncation, no malformation).
 	DelegationChain *DelegationChain `json:"delegation,omitempty"`
 }
 
@@ -152,10 +152,13 @@ func (e *AuditEvent) WithDataFromString(data string) *AuditEvent {
 
 // WithDelegationChain sets the RFC 8693 delegation chain for the event's actor.
 // The chain is attached as-is; parsing raw `act` claims is the caller's
-// responsibility (see ParseDelegationChain). Passing a nil or empty chain
-// clears any previously set chain. Subjects is not modified.
+// responsibility (see ParseDelegationChain). Passing a nil or zero chain
+// (no hops, no truncation, no malformation — see [DelegationChain.IsZero])
+// clears any previously set chain. A hopless but malformed chain is kept:
+// "the caller asserted delegation we could not read" is audit-relevant and
+// distinct from "no delegation". Subjects is not modified.
 func (e *AuditEvent) WithDelegationChain(chain *DelegationChain) *AuditEvent {
-	if chain == nil || chain.IsEmpty() {
+	if chain.IsZero() {
 		e.DelegationChain = nil
 		return e
 	}
@@ -203,38 +206,19 @@ func (e *AuditEvent) LogTo(ctx context.Context, logger *slog.Logger, level slog.
 		attrs = append(attrs, slog.Any("data", e.Data))
 	}
 
-	// Add delegation chain if present and non-empty. The IsEmpty gate plus the
+	// Add delegation chain if present and non-zero. The IsZero gate plus the
 	// field's omitempty tag together guarantee that, when no chain is set,
 	// the log output is identical to before this field existed (no "delegation"
-	// key is emitted). Only iss+sub per hop are logged; extra claims are never
-	// serialized (PII guard).
-	if e.DelegationChain != nil && !e.DelegationChain.IsEmpty() {
-		attrs = append(attrs, delegationLogAttrs(e.DelegationChain))
+	// key is emitted). The chain is emitted via its JSON marshaling so the
+	// slog and JSON wire shapes of the same event are structurally identical:
+	// a "chain" array of {iss,sub} hops plus truncated/omitted/malformed.
+	// Extra per-hop claims are never serialized (PII guard).
+	if !e.DelegationChain.IsZero() {
+		attrs = append(attrs, slog.Any("delegation", e.DelegationChain))
 	}
 
 	// Log with the specified level
 	logger.LogAttrs(ctx, level, "audit_event", attrs...)
-}
-
-// delegationLogAttrs builds the slog attribute group for a delegation chain.
-// Each hop is emitted as a nested slog.Group named hop_0, hop_1, ... inside a
-// "hops" group, containing only iss and sub. The chain's Truncated and
-// Omitted fields are emitted alongside the hops. Extra per-hop claims are
-// deliberately omitted (PII guard).
-func delegationLogAttrs(c *DelegationChain) slog.Attr {
-	hopAttrs := make([]slog.Attr, 0, len(c.Chain))
-	for i, hop := range c.Chain {
-		hopAttrs = append(hopAttrs, slog.Group(
-			fmt.Sprintf("hop_%d", i),
-			slog.String("iss", hop.Issuer),
-			slog.String("sub", hop.Subject),
-		))
-	}
-	return slog.Group("delegation",
-		slog.Any("hops", hopAttrs),
-		slog.Bool("truncated", c.Truncated),
-		slog.Int("omitted", c.Omitted),
-	)
 }
 
 // Common event outcomes

--- a/audit/event.go
+++ b/audit/event.go
@@ -6,6 +6,7 @@ package audit
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -58,6 +59,10 @@ type AuditEvent struct {
 	// Data: enhances the audit event with extra information that may be
 	// useful for forensic analysis.
 	Data *json.RawMessage `json:"data,omitempty"`
+	// DelegationChain holds the RFC 8693 `act` delegation chain when the event's
+	// actor acted on behalf of a prior actor. Additive to Subjects; Subjects
+	// remains the flat backward-compatible identity map. Omitted when empty.
+	DelegationChain *DelegationChain `json:"delegation,omitempty"`
 }
 
 // EventMetadata contains metadata about the audit event.
@@ -145,6 +150,19 @@ func (e *AuditEvent) WithDataFromString(data string) *AuditEvent {
 	return e.WithData(&rawMsg)
 }
 
+// WithDelegationChain sets the RFC 8693 delegation chain for the event's actor.
+// The chain is attached as-is; parsing raw `act` claims is the caller's
+// responsibility (see ParseDelegationChain). Passing a nil or empty chain
+// clears any previously set chain. Subjects is not modified.
+func (e *AuditEvent) WithDelegationChain(chain *DelegationChain) *AuditEvent {
+	if chain == nil || chain.IsEmpty() {
+		e.DelegationChain = nil
+		return e
+	}
+	e.DelegationChain = chain
+	return e
+}
+
 // LevelAudit is a custom slog level for audit events, sitting between
 // [slog.LevelInfo] (0) and [slog.LevelWarn] (4). Logging audit events at this
 // dedicated level lets log infrastructure filter them independently from
@@ -185,8 +203,38 @@ func (e *AuditEvent) LogTo(ctx context.Context, logger *slog.Logger, level slog.
 		attrs = append(attrs, slog.Any("data", e.Data))
 	}
 
+	// Add delegation chain if present and non-empty. The IsEmpty gate plus the
+	// field's omitempty tag together guarantee that, when no chain is set,
+	// the log output is identical to before this field existed (no "delegation"
+	// key is emitted). Only iss+sub per hop are logged; extra claims are never
+	// serialized (PII guard).
+	if e.DelegationChain != nil && !e.DelegationChain.IsEmpty() {
+		attrs = append(attrs, delegationLogAttrs(e.DelegationChain))
+	}
+
 	// Log with the specified level
 	logger.LogAttrs(ctx, level, "audit_event", attrs...)
+}
+
+// delegationLogAttrs builds the slog attribute group for a delegation chain.
+// Each hop is emitted as a nested slog.Group named hop_0, hop_1, ... inside a
+// "hops" group, containing only iss and sub. The chain's Truncated and
+// Omitted fields are emitted alongside the hops. Extra per-hop claims are
+// deliberately omitted (PII guard).
+func delegationLogAttrs(c *DelegationChain) slog.Attr {
+	hopAttrs := make([]slog.Attr, 0, len(c.Chain))
+	for i, hop := range c.Chain {
+		hopAttrs = append(hopAttrs, slog.Group(
+			fmt.Sprintf("hop_%d", i),
+			slog.String("iss", hop.Issuer),
+			slog.String("sub", hop.Subject),
+		))
+	}
+	return slog.Group("delegation",
+		slog.Any("hops", hopAttrs),
+		slog.Bool("truncated", c.Truncated),
+		slog.Int("omitted", c.Omitted),
+	)
 }
 
 // Common event outcomes

--- a/audit/event.go
+++ b/audit/event.go
@@ -209,10 +209,10 @@ func (e *AuditEvent) LogTo(ctx context.Context, logger *slog.Logger, level slog.
 	// Add delegation chain if present and non-zero. The IsZero gate plus the
 	// field's omitempty tag together guarantee that, when no chain is set,
 	// the log output is identical to before this field existed (no "delegation"
-	// key is emitted). The chain is emitted via its JSON marshaling so the
-	// slog and JSON wire shapes of the same event are structurally identical:
-	// a "chain" array of {iss,sub} hops plus truncated/omitted/malformed.
-	// Extra per-hop claims are never serialized (PII guard).
+	// key is emitted). The chain resolves through [DelegationChain.LogValue],
+	// which mirrors its JSON shape, so the slog and JSON wire forms of the same
+	// event are structurally identical and no handler — JSON, text, or custom —
+	// ever sees the unexported extra claims (PII guard).
 	if !e.DelegationChain.IsZero() {
 		attrs = append(attrs, slog.Any("delegation", e.DelegationChain))
 	}

--- a/audit/event_test.go
+++ b/audit/event_test.go
@@ -289,4 +289,12 @@ func TestAuditEventLogTo(t *testing.T) {
 	assert.Equal(t, targetTypeTool, targetData[targetKeyType])
 	assert.Equal(t, "calculator", targetData[targetKeyName])
 	assert.Equal(t, "/api/tools/calculator", targetData[targetKeyEndpt])
+
+	// No delegation chain is attached to this event; the log output must NOT
+	// contain a "delegation" key. This guards the omitempty field tag plus the
+	// IsEmpty gate in LogTo so that, when no chain is set, output is identical
+	// to before the delegation field existed.
+	assert.NotContains(t, logOutput, "delegation", "no delegation key when chain is unset")
+	_, hasDelegation := logEntry["delegation"]
+	assert.False(t, hasDelegation, "parsed log entry must not have a delegation key")
 }

--- a/audit/event_test.go
+++ b/audit/event_test.go
@@ -292,7 +292,7 @@ func TestAuditEventLogTo(t *testing.T) {
 
 	// No delegation chain is attached to this event; the log output must NOT
 	// contain a "delegation" key. This guards the omitempty field tag plus the
-	// IsEmpty gate in LogTo so that, when no chain is set, output is identical
+	// IsZero gate in LogTo so that, when no chain is set, output is identical
 	// to before the delegation field existed.
 	assert.NotContains(t, logOutput, "delegation", "no delegation key when chain is unset")
 	_, hasDelegation := logEntry["delegation"]


### PR DESCRIPTION
## Summary

Adds typed, additive RFC 8693 `act` delegation-chain support to the `audit` package, so audit events can capture the actor identity and full delegation chain of a delegated token — not just the terminal `sub`. This closes the shared-library side of stacklok/toolhive#6035 ("Alice did X" vs "Alice's agent did X on her behalf").

**This package is intended to be canonical**: toolhive's `pkg/audit`/`pkg/auth` delegation schema (stacklok/toolhive#6046, #6096) will be reconciled to match this one at migration time.

## What changed

- **`DelegatedActor`** — one hop, identified by typed `iss`+`sub` only (OIDC Connect Core §5.7: the (iss, sub) pair is the only stable, unique actor identifier; RFC 8693 §6 data minimization). All other per-hop claims are retained in memory only and are **never serialized or logged** (PII guard; NIST AU-3(1)/(3) audit-record minimization); accessible via `Extra()` (shallow copy, documented as must-not-be-logged).
- **`DelegationChain`** — flattened, **outermost-first** (`Chain[0]` = current actor, per RFC 8693 §4.1 the only hop that may drive access control; prior hops informational). Current-actor-first keeps `Chain[0]` stable under truncation. `Truncated`/`Omitted`/`Malformed` are always emitted — an incomplete or non-conformant chain is never silently indistinguishable from a complete, well-formed one.
- **Record-and-flag malformed handling** — `ParseDelegationChain(raw, maxDepth) *DelegationChain` **never fails**. Non-conformant input (non-object `act`, non-object nested `act`, non-string `iss`/`sub`) sets `Malformed` plus a low-cardinality `MalformedReason` enum (`act_not_object`, `nested_act_not_object`, `iss_not_string`, `sub_not_string`) and preserves every hop parsed before the violation. An audit record must be producible for exactly the tokens that violate expectations: dropping the record on malformed attacker-influenceable input is an indicator-blocking primitive (MITRE ATT&CK T1562.006; CWE-223/CWE-778), and per RFC 8693 §4.1 prior actors are informational-only, so a malformed chain cannot legitimately fail authorization — recording it is its only purpose. Strict rejection belongs on the token-issuance path (see stacklok/toolhive#6093).
- **`Chain` is always allocated** — the wire always carries `"chain": []`, never `"chain": null` (guarded by a test asserting emitted bytes).
- **Named map types** (e.g. `jwt.MapClaims`) are accepted at any nesting level via a reflection fallback, so programmatically built claims don't silently parse as non-objects.
- **`AuditEvent.DelegationChain`** (`json:"delegation,omitempty"`) + **`WithDelegationChain`** builder. Zero chains (no hops, no truncation, no malformation) are cleared; hopless-but-malformed chains are kept. `Subjects` is **untouched** — the delegating end user is the token's top-level `sub` in `Subjects`, not a chain entry.
- **`LogTo` emits the chain via its JSON marshaling** (`slog.Any`), so the slog and JSON wire shapes of the same event are structurally identical — one parser serves both (guarded by a shape-equality test).
- Fixed the pre-existing `doc.go` bug and added a *Delegation Chains* section documenting ordering, the PII stance, and the malformed-input policy.

## Backward compatibility

**Purely additive — no breaking changes.** One additive struct field with `omitempty`; no constructor/signature changes; `Subjects` contract unchanged. With no chain set, JSON and log output are **byte-identical to before** (guarded by tests). No new dependencies (stdlib only).

## Design decisions

- **Flag, not error.** Evidence: NIST SP 800-53 AU-3(f) (records must identify subjects, no "only if parseable" qualifier) + AU-5 (alert, don't halt); OWASP ASVS 5.0 16.5.3/16.5.4 (fail closed on the *operation*, never lose the error details from the *log*); RFC 9413 (forbids *silent* tolerance — a loud flag satisfies it, discarding violates it); syslog RFC 3164 §4.3.3 record-and-flag precedent; CloudTrail's first-class `userIdentity.type: Unknown`. The reason field is an enum, not free text, per OTel `error.type` low-cardinality guidance, so it is safe as a metric/alert dimension.
- **Depth default 16 (not 10):** this is a *parse-time defensive ceiling* for a shared library, deliberately above any consumer's minting cap, so that for a consumer passing its mint cap (toolhive: 10; draft-mw-spice-actor-chain §21.9 RECOMMENDED default: 10), `truncated: true` is a genuine signal that a token came from outside its own issuance path.
- Chain type lives **directly in the `audit` package**, auth-agnostic — `ParseDelegationChain` takes an already-decoded `any`, no JWT dependency.
- No auto-mirroring of the actor into `Subjects` (avoids smuggled side effects in builders).

## Test plan

`task` green (golangci-lint 0 issues, `go vet` clean, race tests pass); `task license-check` passes. Audit package coverage **99.0%**. Tests assert **emitted JSON keys, not Go struct fields** (tag renames cannot pass with a green suite); pin `"chain":[]` vs `null`; verify slog/JSON shape equality; cover nested parse (0/1/N hops), outermost-first ordering, exactly-at-cap / cap+1 / depth-1000 truncation with exact omitted counts, malformed-past-cap semantics, non-string `sub`/`iss` (flag + in-memory retention), named map types, first-reason-wins, extra-claims PII guards in both JSON and slog output, JSON round-trip, and omit-empty/backward-compat guards.

Refs stacklok/toolhive#6035