### PR TITLE
Relax pre-release go-sdk release guard to a warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # toolhive-core is a shared library: a pre-release go-sdk require
-      # propagates to every downstream consumer via MVS. Fail the release
-      # job so nobody accidentally tags a release pinned to a go-sdk
-      # pre-release (see the inline comment on the go-sdk require in go.mod).
+      # propagates to every downstream consumer via MVS. Warn on release so
+      # it's obvious a go-sdk pre-release is pinned (see the inline comment
+      # on the go-sdk require in go.mod), without blocking releases needed
+      # before go-sdk v1.7.0 final ships.
       - name: Guard against pre-release go-sdk dependency
         run: |
           if grep -qE 'github\.com/modelcontextprotocol/go-sdk v[0-9]+\.[0-9]+\.[0-9]+-(pre|rc)' go.mod; then
-            echo "::error file=go.mod::go.mod pins a pre-release go-sdk version; do not tag a toolhive-core release until go-sdk final ships"
+            echo "::warning file=go.mod::go.mod pins a pre-release go-sdk version; confirm this release is intentional before go-sdk final ships"
             grep -nE 'github\.com/modelcontextprotocol/go-sdk v[0-9]+\.[0-9]+\.[0-9]+-(pre|rc)' go.mod
-            exit 1
           fi
 
       - name: Upload schema artifacts to release


### PR DESCRIPTION
## Summary
- The `Publish Release Artifacts` job hard-fails whenever `go.mod` pins a pre-release `go-sdk` (`v1.7.0-pre.3` currently), which blocked tag `v0.0.34` from https://github.com/stacklok/toolhive-core/actions/runs/30162943590/job/89691111577
- Since go-sdk `v1.7.0` final hasn't shipped yet, this turns the hard failure into a non-blocking `::warning`, so releases can still go out while the pre-release dependency is visibly flagged
- Once go-sdk `v1.7.0` final ships and `go.mod` is bumped, this warning naturally stops firing

## Test plan
- [ ] Re-run/tag a release and confirm the job succeeds with a warning annotation instead of failing