### PR TITLE
Bump go-sdk to v1.7.0 final ahead of v0.0.35 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3 // PRE-RELEASE: do NOT tag a toolhive-core release until go-sdk v1.7.0 final ships (MCP 2026-07-28 stateless work; re-bump then)
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/modelcontextprotocol/registry v1.8.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3 h1:SEAY9IduDif4iApnZgpFkjFIdo3askSGZVbZIYyTy6I=
-github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modelcontextprotocol/registry v1.8.0 h1:x/seX0ji4iqRUpSovmkBcGbxfRiZZ7dgPwBcpCJrSTM=
 github.com/modelcontextprotocol/registry v1.8.0/go.mod h1:G6AUpTpZSekQvcLl5griUjijEE8vedARE/TyCaHEFdo=
 github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=


### PR DESCRIPTION
go-sdk v1.7.0 final shipped today (2026-07-28T13:09Z), consolidating the pre.1–pre.3 series and finalizing MCP protocol 2026-07-28 support. This clears the `v1.7.0-pre.3` pin and its "do NOT tag a release until final ships; re-bump then" note in go.mod, per that instruction — unblocking the v0.0.35 release (which will be the first tag since the release workflow's pre-release guard was relaxed in #199; v0.0.34's release job was blocked by the old guard).

`task` fully green against final: lint 0 issues, race tests pass across all packages including the `mcpcompat/*` shims that exercise go-sdk directly. `go mod verify` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)