### PR TITLE
Add MCP semantic-convention histogram bucket preset

### DIFF
--- a/telemetry/metrics/metrics.go
+++ b/telemetry/metrics/metrics.go
@@ -15,6 +15,16 @@ func BucketsMCPProxy() []float64 {
 	return []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300}
 }
 
+// BucketsMCPSemconv returns the histogram bucket boundaries, in seconds,
+// defined by the OpenTelemetry MCP semantic conventions for MCP server
+// histograms (e.g. mcp.server.operation.duration). Unlike BucketsMCPProxy —
+// a coarser Stacklok platform preset — this preset tracks the upstream
+// semconv boundary set exactly, for emitters that promise semconv fidelity.
+// See https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/mcp.md
+func BucketsMCPSemconv() []float64 {
+	return []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300}
+}
+
 // BucketsLongRunning returns the histogram bucket boundaries, in seconds, for
 // long-running measurements such as sync, reconcile, or composite-tool
 // durations (RFC §3.3: 0.1-300).

--- a/telemetry/metrics/metrics_test.go
+++ b/telemetry/metrics/metrics_test.go
@@ -32,6 +32,11 @@ func TestBucketPresets(t *testing.T) {
 			[]float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300},
 		},
 		{
+			"MCP semconv",
+			BucketsMCPSemconv,
+			[]float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300},
+		},
+		{
 			"long-running",
 			BucketsLongRunning,
 			[]float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 180, 300},


### PR DESCRIPTION
## Summary

Add `BucketsMCPSemconv()` to `telemetry/metrics` — a histogram bucket preset tracking the OTel MCP semantic-convention boundary set exactly (`0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300`), per https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/mcp.md.

## Why

The existing `BucketsMCPProxy()` is a coarser Stacklok platform preset (drops 0.02/0.2/2, adds 0.25/2.5). ToolHive's MCP histograms (`mcp.server.operation.duration`) follow the semconv set and can't adopt the platform preset without breaking existing dashboards. This lets toolhive consume its bucket set from core instead of defining it locally (first step of the toolhive→toolhive-core telemetry migration).

Purely additive; no changes to existing presets.

## Test plan

- [x] `task test` — new table entry pins the full boundary set + strict-increasing + independent-slice invariants
- [x] `task lint-fix` — 0 issues
