### PR TITLE
Add panic handler hooks and ErrAbortHandler passthrough to recovery

### DIFF
--- a/recovery/doc.go
+++ b/recovery/doc.go
@@ -22,6 +22,19 @@
 //	logger := logging.New()
 //	wrappedMux := recovery.Middleware(mux, recovery.WithLogger(logger))
 //
+// # Panic reporting
+//
+// Use [WithPanicHandler] to forward recovered panics to observability
+// backends. RecordError receives a sanitized, value-free error suitable
+// for tracing spans; ReportPanic receives the raw panic value for
+// operator-configured error trackers.
+//
+// # Abort-handler passthrough
+//
+// A panic of [http.ErrAbortHandler] (or an error wrapping it) is
+// re-panicked rather than recovered, preserving net/http and
+// httputil.ReverseProxy streaming-abort semantics.
+//
 // # Stability
 //
 // This package is Beta stability. The API may have minor changes before

--- a/recovery/handler.go
+++ b/recovery/handler.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package recovery
+
+import "net/http"
+
+// PanicHandler receives recovered panics for observability backends.
+// Implementations must be safe for concurrent use and must not panic.
+//
+// The two methods exist because backends have different data-safety
+// contracts:
+//
+//   - RecordError is for telemetry that ships to shared/external systems
+//     (tracing spans, metrics). It receives a generic error whose message
+//     never contains the panic value, so implementations can safely attach
+//     it to spans or error records.
+//   - ReportPanic is for error-tracking backends the operator explicitly
+//     configured (e.g. Sentry Issues). It receives the raw recovered panic
+//     value, which such backends need to group and triage the failure.
+type PanicHandler interface {
+	// RecordError records a sanitized error for the request's panic.
+	// The error message is always generic ("panic recovered") and contains
+	// no panic value.
+	RecordError(r *http.Request, err error)
+
+	// ReportPanic reports the raw recovered panic value for the request.
+	ReportPanic(r *http.Request, panicValue any)
+}
+
+// PanicHandlerFunc adapts a single function to PanicHandler, calling it
+// from both RecordError and ReportPanic. The function receives the panic
+// value on ReportPanic and nil on RecordError. Prefer implementing
+// PanicHandler directly when the two channels need different treatment.
+type PanicHandlerFunc func(r *http.Request, panicValue any)
+
+// RecordError calls f(r, nil).
+func (f PanicHandlerFunc) RecordError(r *http.Request, _ error) { f(r, nil) }
+
+// ReportPanic calls f(r, panicValue).
+func (f PanicHandlerFunc) ReportPanic(r *http.Request, panicValue any) { f(r, panicValue) }

--- a/recovery/recovery.go
+++ b/recovery/recovery.go
@@ -4,6 +4,7 @@
 package recovery
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -12,7 +13,8 @@ import (
 
 // config holds the resolved configuration for the recovery middleware.
 type config struct {
-	logger *slog.Logger
+	logger  *slog.Logger
+	handler PanicHandler
 }
 
 // Option configures the recovery middleware.
@@ -27,12 +29,31 @@ func WithLogger(l *slog.Logger) Option {
 	}
 }
 
+// WithPanicHandler sets the handler invoked when a panic is recovered.
+// Typical implementations record the panic on a tracing span and/or report
+// it to an error-tracking backend such as Sentry. The handler runs after
+// logging and before the 500 response is written.
+//
+// The handler must not panic itself; a panicking handler crashes the
+// serving goroutine just as an unrecovered panic would.
+func WithPanicHandler(h PanicHandler) Option {
+	return func(c *config) {
+		c.handler = h
+	}
+}
+
 // Middleware is an HTTP middleware that recovers from panics.
 // When a panic occurs, it returns a 500 Internal Server Error response
 // to the client, preventing the panic from crashing the server.
 //
-// Options can be provided to configure logging behavior. By default,
-// panics are recovered silently. Use [WithLogger] to enable logging.
+// A panic of [http.ErrAbortHandler] (or an error wrapping it) is re-panicked
+// instead of recovered: net/http and httputil.ReverseProxy use that sentinel
+// to abort in-flight streaming responses, and recovering it would corrupt
+// the response and log noisy stack traces for a normal disconnect.
+//
+// Options can be provided to configure logging and panic reporting. By
+// default, panics are recovered silently. Use [WithLogger] to enable
+// logging and [WithPanicHandler] to report panics to observability backends.
 func Middleware(next http.Handler, opts ...Option) http.Handler {
 	cfg := &config{}
 	for _, opt := range opts {
@@ -42,6 +63,14 @@ func Middleware(next http.Handler, opts ...Option) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if v := recover(); v != nil {
+				// Re-panic http.ErrAbortHandler so Go's HTTP server can
+				// handle it as designed (silently close the connection).
+				// ReverseProxy panics with this sentinel when a streaming
+				// response breaks mid-copy; catching it would log noisy
+				// stack traces and corrupt the already-in-flight response.
+				if isErrAbortHandler(v) {
+					panic(http.ErrAbortHandler)
+				}
 				if cfg.logger != nil {
 					stack := debug.Stack()
 					cfg.logger.ErrorContext(r.Context(), "panic recovered",
@@ -51,9 +80,40 @@ func Middleware(next http.Handler, opts ...Option) http.Handler {
 						slog.String("stack", string(stack)),
 					)
 				}
+				if cfg.handler != nil {
+					// RecordError receives a generic message, not the panic
+					// value: panic values may embed credentials or internal
+					// state that must not reach external telemetry backends.
+					// Full details are in the log and in ReportPanic, which
+					// is for backends the operator explicitly configured.
+					cfg.handler.RecordError(r, errors.New("panic recovered"))
+					cfg.handler.ReportPanic(r, v)
+				}
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			}
 		}()
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isErrAbortHandler reports whether v is the net/http abort-handler sentinel
+// or an error wrapping it (see errors.Is). httputil.ReverseProxy uses this
+// panic to stop copying a streaming response when the backend or client drops
+// the connection.
+//
+// It must not be treated as a normal panic: logging it as ERROR and calling
+// http.Error would run after headers may already be sent (SSE), which
+// produces "superfluous response.WriteHeader" and corrupts the response.
+func isErrAbortHandler(v any) bool {
+	if v == nil {
+		return false
+	}
+	if v == http.ErrAbortHandler {
+		return true
+	}
+	err, ok := v.(error)
+	if !ok {
+		return false
+	}
+	return errors.Is(err, http.ErrAbortHandler)
 }

--- a/recovery/recovery_test.go
+++ b/recovery/recovery_test.go
@@ -6,6 +6,8 @@ package recovery
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -158,4 +160,114 @@ func TestMiddleware_PreservesRequestContext(t *testing.T) {
 	// Verify context was preserved
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, value, receivedValue)
+}
+
+type recordingPanicHandler struct {
+	recordErrs   []error
+	reportValues []any
+}
+
+func (h *recordingPanicHandler) RecordError(_ *http.Request, err error) {
+	h.recordErrs = append(h.recordErrs, err)
+}
+
+func (h *recordingPanicHandler) ReportPanic(_ *http.Request, v any) {
+	h.reportValues = append(h.reportValues, v)
+}
+
+func TestMiddleware_PanicHandlerInvoked(t *testing.T) {
+	t.Parallel()
+
+	handler := &recordingPanicHandler{}
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("secret-bearing panic value")
+	})
+
+	wrappedHandler := Middleware(testHandler, WithPanicHandler(handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	wrappedHandler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+
+	// RecordError must receive a sanitized error: the panic value must not
+	// leak into telemetry-bound error records.
+	if assert.Len(t, handler.recordErrs, 1) {
+		assert.Equal(t, "panic recovered", handler.recordErrs[0].Error())
+		assert.NotContains(t, handler.recordErrs[0].Error(), "secret-bearing")
+	}
+
+	// ReportPanic receives the raw value for operator-configured trackers.
+	if assert.Len(t, handler.reportValues, 1) {
+		assert.Equal(t, "secret-bearing panic value", handler.reportValues[0])
+	}
+}
+
+func TestMiddleware_PanicHandlerNotInvokedWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	handler := &recordingPanicHandler{}
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	wrappedHandler := Middleware(testHandler, WithPanicHandler(handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+	wrappedHandler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, handler.recordErrs)
+	assert.Empty(t, handler.reportValues)
+}
+
+func TestMiddleware_ErrAbortHandlerRePanicked(t *testing.T) {
+	t.Parallel()
+
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	handler := &recordingPanicHandler{}
+	wrappedHandler := Middleware(testHandler, WithPanicHandler(handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		v := recover()
+		assert.Equal(t, http.ErrAbortHandler, v, "ErrAbortHandler must propagate, not be recovered")
+	}()
+	wrappedHandler.ServeHTTP(rec, req)
+}
+
+func TestMiddleware_WrappedErrAbortHandlerRePanicked(t *testing.T) {
+	t.Parallel()
+
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic(fmt.Errorf("stream copy aborted: %w", http.ErrAbortHandler))
+	})
+
+	wrappedHandler := Middleware(testHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		v := recover()
+		assert.Equal(t, http.ErrAbortHandler, v, "wrapped ErrAbortHandler must re-panic as the bare sentinel")
+	}()
+	wrappedHandler.ServeHTTP(rec, req)
+}
+
+func TestIsErrAbortHandler(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isErrAbortHandler(nil))
+	assert.False(t, isErrAbortHandler("some string panic"))
+	assert.False(t, isErrAbortHandler(errors.New("boom")))
+	assert.True(t, isErrAbortHandler(http.ErrAbortHandler))
+	assert.True(t, isErrAbortHandler(fmt.Errorf("wrap: %w", http.ErrAbortHandler)))
 }


### PR DESCRIPTION
## Summary

Extend the `recovery` middleware so toolhive can adopt it without losing its existing observability behavior (wave 1 of the toolhive→toolhive-core migration, plan in toolhive `.claude/scratch/core-migration-plan.md`):

- **`PanicHandler` interface + `WithPanicHandler` option** — two channels with distinct data-safety contracts:
  - `RecordError(r, err)` receives a sanitized `"panic recovered"` error (never the panic value) for telemetry-bound records like tracing spans.
  - `ReportPanic(r, v)` receives the raw panic value for operator-configured error trackers (e.g. Sentry Issues).
- **`http.ErrAbortHandler` passthrough** — a panic of the sentinel (or an error wrapping it, via `errors.Is`) is re-panicked instead of recovered. `httputil.ReverseProxy` uses it to abort streaming responses (SSE) on disconnect; recovering it logs noisy stack traces and corrupts in-flight responses. Ported verbatim from toolhive's `pkg/recovery/recovery.go`.

Purely additive: `Middleware(next)` with no options behaves exactly as before (silent recovery + 500), modulo the ErrAbortHandler passthrough which is a bug-compatible-with-stdlib fix.

## Test plan

- [x] `task test` — new tests pin: handler invocation + sanitization boundary, no spurious calls on success, bare and wrapped `ErrAbortHandler` re-panic, `isErrAbortHandler` truth table
- [x] `task lint-fix` — 0 issues
