### PR TITLE
Add container images keychain helpers

### DIFF
--- a/container/images/doc.go
+++ b/container/images/doc.go
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package images provides container image registry helpers for the ToolHive
+// ecosystem: credential keychains for go-containerregistry and related
+// image-reference utilities.
+//
+// The keychains resolve registry credentials from environment variables
+// (per-registry or generic) before falling back to the default Docker
+// config keychain, so headless environments (CI, Kubernetes pods) can
+// authenticate without a Docker config file.
+//
+// This package is Alpha stability. The API may change significantly before
+// reaching stable status in v1.0.0.
+package images

--- a/container/images/keychain.go
+++ b/container/images/keychain.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package images
+
+import (
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+// envKeychain implements a keychain that reads credentials from environment variables
+type envKeychain struct{}
+
+// Resolve implements the authn.Keychain interface
+func (*envKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	registry := target.RegistryStr()
+
+	// Try registry-specific environment variables first
+	// Format: REGISTRY_<NORMALIZED_REGISTRY_NAME>_USERNAME/PASSWORD, i.e., REGISTRY_DOCKER_IO_USERNAME
+	normalizedRegistry := strings.ToUpper(strings.ReplaceAll(registry, ".", "_"))
+	normalizedRegistry = strings.ReplaceAll(normalizedRegistry, "-", "_")
+
+	username := os.Getenv("REGISTRY_" + normalizedRegistry + "_USERNAME")
+	password := os.Getenv("REGISTRY_" + normalizedRegistry + "_PASSWORD")
+
+	// If registry-specific vars not found, try generic one REGISTRY_USERNAME/PASSWORD
+	if username == "" || password == "" {
+		username = os.Getenv("REGISTRY_USERNAME")
+		password = os.Getenv("REGISTRY_PASSWORD")
+	}
+
+	if username != "" && password != "" {
+		return &authn.Basic{
+			Username: username,
+			Password: password,
+		}, nil
+	}
+
+	return authn.Anonymous, nil
+}
+
+// compositeKeychain combines multiple keychains and tries them in order
+type compositeKeychain struct {
+	keychains []authn.Keychain
+}
+
+// Resolve implements the authn.Keychain interface
+func (c *compositeKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	for _, keychain := range c.keychains {
+		auth, err := keychain.Resolve(target)
+		if err != nil {
+			continue
+		}
+
+		// Check if we got actual credentials (not anonymous)
+		if auth != authn.Anonymous {
+			return auth, nil
+		}
+	}
+
+	// If no keychain provided credentials, return anonymous
+	return authn.Anonymous, nil
+}
+
+// NewCompositeKeychain creates a keychain that tries environment variables first,
+// then falls back to the default keychain
+func NewCompositeKeychain() authn.Keychain {
+	return &compositeKeychain{
+		keychains: []authn.Keychain{
+			&envKeychain{},        // Try environment variables first
+			authn.DefaultKeychain, // Then try default keychain (Docker config, etc.)
+		},
+	}
+}

--- a/container/images/keychain_test.go
+++ b/container/images/keychain_test.go
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: Copyright 2025 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package images
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustResource(t *testing.T, registry string) authn.Resource {
+	t.Helper()
+	reg, err := name.NewRegistry(registry)
+	require.NoError(t, err)
+	return reg
+}
+
+func TestEnvKeychain_RegistrySpecific(t *testing.T) {
+	t.Setenv("REGISTRY_GHCR_IO_USERNAME", "alice")
+	t.Setenv("REGISTRY_GHCR_IO_PASSWORD", "s3cret")
+
+	auth, err := (&envKeychain{}).Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+	require.NotEqual(t, authn.Anonymous, auth)
+
+	cfg, err := auth.Authorization()
+	require.NoError(t, err)
+	assert.Equal(t, "alice", cfg.Username)
+	assert.Equal(t, "s3cret", cfg.Password)
+}
+
+func TestEnvKeychain_NormalizesDashes(t *testing.T) {
+	t.Setenv("REGISTRY_MY_REGISTRY_EXAMPLE_COM_USERNAME", "bob")
+	t.Setenv("REGISTRY_MY_REGISTRY_EXAMPLE_COM_PASSWORD", "tok")
+
+	auth, err := (&envKeychain{}).Resolve(mustResource(t, "my-registry.example.com"))
+	require.NoError(t, err)
+
+	cfg, err := auth.Authorization()
+	require.NoError(t, err)
+	assert.Equal(t, "bob", cfg.Username)
+	assert.Equal(t, "tok", cfg.Password)
+}
+
+func TestEnvKeychain_GenericFallback(t *testing.T) {
+	t.Setenv("REGISTRY_USERNAME", "generic-user")
+	t.Setenv("REGISTRY_PASSWORD", "generic-pass")
+
+	auth, err := (&envKeychain{}).Resolve(mustResource(t, "registry.example.com"))
+	require.NoError(t, err)
+
+	cfg, err := auth.Authorization()
+	require.NoError(t, err)
+	assert.Equal(t, "generic-user", cfg.Username)
+	assert.Equal(t, "generic-pass", cfg.Password)
+}
+
+func TestEnvKeychain_RegistrySpecificWinsOverGeneric(t *testing.T) {
+	t.Setenv("REGISTRY_USERNAME", "generic-user")
+	t.Setenv("REGISTRY_PASSWORD", "generic-pass")
+	t.Setenv("REGISTRY_GHCR_IO_USERNAME", "specific-user")
+	t.Setenv("REGISTRY_GHCR_IO_PASSWORD", "specific-pass")
+
+	auth, err := (&envKeychain{}).Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+
+	cfg, err := auth.Authorization()
+	require.NoError(t, err)
+	assert.Equal(t, "specific-user", cfg.Username)
+}
+
+func TestEnvKeychain_AnonymousWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	auth, err := (&envKeychain{}).Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+	assert.Equal(t, authn.Anonymous, auth)
+}
+
+func TestEnvKeychain_AnonymousWhenPartiallySet(t *testing.T) {
+	t.Setenv("REGISTRY_GHCR_IO_USERNAME", "alice")
+	// no password
+
+	auth, err := (&envKeychain{}).Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+	assert.Equal(t, authn.Anonymous, auth)
+}
+
+type fixedKeychain struct {
+	auth authn.Authenticator
+	err  error
+}
+
+func (k *fixedKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return k.auth, k.err
+}
+
+func TestCompositeKeychain_FirstNonAnonymousWins(t *testing.T) {
+	t.Parallel()
+
+	specific := &authn.Basic{Username: "u", Password: "p"}
+	kc := &compositeKeychain{keychains: []authn.Keychain{
+		&fixedKeychain{auth: authn.Anonymous},
+		&fixedKeychain{auth: specific},
+	}}
+
+	auth, err := kc.Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+	assert.Equal(t, specific, auth)
+}
+
+func TestCompositeKeychain_SkipsErrors(t *testing.T) {
+	t.Parallel()
+
+	specific := &authn.Basic{Username: "u", Password: "p"}
+	kc := &compositeKeychain{keychains: []authn.Keychain{
+		&fixedKeychain{err: assert.AnError},
+		&fixedKeychain{auth: specific},
+	}}
+
+	auth, err := kc.Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+	assert.Equal(t, specific, auth)
+}
+
+func TestCompositeKeychain_AllAnonymous(t *testing.T) {
+	t.Parallel()
+
+	kc := &compositeKeychain{keychains: []authn.Keychain{
+		&fixedKeychain{auth: authn.Anonymous},
+		&fixedKeychain{auth: authn.Anonymous},
+	}}
+
+	auth, err := kc.Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+	assert.Equal(t, authn.Anonymous, auth)
+}
+
+func TestNewCompositeKeychain_EnvFirst(t *testing.T) {
+	t.Setenv("REGISTRY_USERNAME", "env-user")
+	t.Setenv("REGISTRY_PASSWORD", "env-pass")
+
+	auth, err := NewCompositeKeychain().Resolve(mustResource(t, "ghcr.io"))
+	require.NoError(t, err)
+
+	cfg, err := auth.Authorization()
+	require.NoError(t, err)
+	assert.Equal(t, "env-user", cfg.Username, "env credentials must win over the default keychain")
+}


### PR DESCRIPTION
## Summary

Move toolhive's `pkg/container/images/keychain.go` into core as `container/images` (wave 2 of the toolhive→toolhive-core migration).

The keychain resolves registry credentials from environment variables (`REGISTRY_<NORMALIZED>_USERNAME/PASSWORD`, then generic `REGISTRY_USERNAME/PASSWORD`) before falling back to `authn.DefaultKeychain` — used by toolhive's sigstore verifier for private-registry images, and reusable by any ecosystem service pulling from authenticated registries without a Docker config file.

The rest of toolhive's `pkg/container/images` (`RegistryImageManager`) does **not** move: it is deeply coupled to the moby client (`daemon.Write`, `daemon.Image`, `ImagePull`, `ImageBuild`), and the `daemon.Client` seam is satisfied by `*mobyclient.Client`, so extracting it would mean either a new heavy core dependency or re-implementing the daemon client. It stays in toolhive.

Verbatim move + new test suite (the original had none):
- env keychain: registry-specific, dash/dot normalization, generic fallback, precedence, anonymous on unset/partial
- composite keychain: first-non-anonymous wins, error skipping, all-anonymous
- `NewCompositeKeychain`: env beats default

One quirk surfaced by the tests: go-containerregistry's `RegistryStr()` returns `index.docker.io` for Docker Hub, so the per-registry env var for Docker Hub is `REGISTRY_INDEX_DOCKER_IO_*`, not `REGISTRY_DOCKER_IO_*` as the original comment implies. Tests pin actual behavior (ghcr.io used as the fixture).

## Test plan

- [x] `task test` — 26 packages pass incl. new keychain suite
- [x] `task lint-fix` — 0 issues
