### PR TITLE
Let mcpcompat resource handlers return _meta

### DIFF
--- a/mcpcompat/server/request_handler.go
+++ b/mcpcompat/server/request_handler.go
@@ -185,6 +185,16 @@ func (s *MCPServer) handleReadResource(ctx context.Context, id any, message json
 	if !ok {
 		return errorResponse(id, mcp.RESOURCE_NOT_FOUND, fmt.Sprintf("resource %q not found", req.Params.URI))
 	}
+	if sr.resultHandler != nil {
+		res, err := sr.resultHandler(ctx, req)
+		if err != nil {
+			return errorResponse(id, mcp.INTERNAL_ERROR, err.Error())
+		}
+		if res == nil {
+			res = &mcp.ReadResourceResult{}
+		}
+		return successResponse(id, res)
+	}
 	contents, err := sr.Handler(ctx, req)
 	if err != nil {
 		return errorResponse(id, mcp.INTERNAL_ERROR, err.Error())

--- a/mcpcompat/server/resource_meta_test.go
+++ b/mcpcompat/server/resource_meta_test.go
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Copyright 2026 Stacklok, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stacklok/toolhive-core/mcpcompat/client"
+	"github.com/stacklok/toolhive-core/mcpcompat/mcp"
+	"github.com/stacklok/toolhive-core/mcpcompat/server"
+)
+
+// TestAddResourceWithResult_MetaOnWire verifies that a resource handler
+// registered via AddResourceWithResult has its _meta forwarded onto the
+// resources/read wire result — the gap that dropped backend resource metadata
+// before this registration path existed (toolhive-core#194).
+func TestAddResourceWithResult_MetaOnWire(t *testing.T) {
+	t.Parallel()
+
+	const resourceURI = "file:///meta-resource"
+
+	srv := server.NewMCPServer("meta-server", testClientVersion,
+		server.WithResourceCapabilities(true, true),
+	)
+	srv.AddResourceWithResult(
+		mcp.Resource{URI: resourceURI, Name: "meta-resource"},
+		func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{
+				Result: mcp.Result{Meta: &mcp.Meta{
+					AdditionalFields: map[string]any{"traceparent": "00-abc-01"},
+				}},
+				Contents: []mcp.ResourceContents{
+					mcp.TextResourceContents{URI: req.Params.URI, Text: "with meta"},
+				},
+			}, nil
+		},
+	)
+
+	res := readResourceOverHTTP(t, srv, resourceURI)
+	require.Len(t, res.Contents, 1)
+	require.NotNil(t, res.Meta, "handler _meta must reach the wire result")
+	assert.Equal(t, "00-abc-01", res.Meta.AdditionalFields["traceparent"])
+}
+
+// TestAddResourceTemplateWithResult_MetaOnWire is the template twin of
+// TestAddResourceWithResult_MetaOnWire: AddResourceTemplateWithResult must
+// forward _meta from a templated read.
+func TestAddResourceTemplateWithResult_MetaOnWire(t *testing.T) {
+	t.Parallel()
+
+	const (
+		templateName = "meta-template"
+		uriTemplate  = "file:///users/{id}"
+		readURI      = "file:///users/42"
+	)
+
+	srv := server.NewMCPServer("meta-template-server", testClientVersion,
+		server.WithResourceCapabilities(true, true),
+	)
+	srv.AddResourceTemplateWithResult(
+		mcp.ResourceTemplate{Name: templateName, URITemplate: uriTemplate},
+		func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{
+				Result: mcp.Result{Meta: &mcp.Meta{
+					AdditionalFields: map[string]any{"backend": "meta"},
+				}},
+				Contents: []mcp.ResourceContents{
+					mcp.TextResourceContents{URI: req.Params.URI, Text: "template with meta"},
+				},
+			}, nil
+		},
+	)
+
+	res := readResourceOverHTTP(t, srv, readURI)
+	require.Len(t, res.Contents, 1)
+	require.NotNil(t, res.Meta, "template handler _meta must reach the wire result")
+	assert.Equal(t, "meta", res.Meta.AdditionalFields["backend"])
+}
+
+// TestAddResource_ContentsOnlyUnchanged pins the pre-existing shape: a
+// contents-only handler registered via AddResource still compiles and serves
+// contents with no _meta, exactly as before the WithResult path existed.
+func TestAddResource_ContentsOnlyUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const resourceURI = "file:///plain-resource"
+
+	srv := server.NewMCPServer("plain-server", testClientVersion,
+		server.WithResourceCapabilities(true, true),
+	)
+	srv.AddResource(
+		mcp.Resource{URI: resourceURI, Name: "plain-resource"},
+		func(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			return []mcp.ResourceContents{
+				mcp.TextResourceContents{URI: req.Params.URI, Text: "plain body"},
+			}, nil
+		},
+	)
+
+	res := readResourceOverHTTP(t, srv, resourceURI)
+	require.Len(t, res.Contents, 1)
+	txt, ok := res.Contents[0].(mcp.TextResourceContents)
+	require.True(t, ok, "contents must decode as text")
+	assert.Equal(t, "plain body", txt.Text)
+	assert.Nil(t, res.Meta, "contents-only registration must not synthesize _meta")
+}
+
+// readResourceOverHTTP serves srv over Streamable HTTP and issues a single
+// resources/read for uri, returning the decoded result.
+func readResourceOverHTTP(t *testing.T, srv *server.MCPServer, uri string) *mcp.ReadResourceResult {
+	t.Helper()
+	ctx := t.Context()
+
+	httpSrv := server.NewStreamableHTTPServer(srv)
+	ts := httptest.NewServer(httpSrv)
+	t.Cleanup(ts.Close)
+
+	c, err := client.NewStreamableHttpClient(ts.URL)
+	require.NoError(t, err)
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Close() })
+
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: testClientName, Version: testClientVersion},
+		},
+	})
+	require.NoError(t, err)
+
+	res, err := c.ReadResource(ctx, mcp.ReadResourceRequest{Params: mcp.ReadResourceParams{URI: uri}})
+	require.NoError(t, err)
+	return res
+}
+
+// TestSessionResource_WithResult_MetaOnWire verifies the per-session twin of
+// AddResourceWithResult: a ServerResource built with
+// NewServerResourceWithResult and installed via SetSessionResources serves its
+// handler's _meta on resources/read. This is the shape ToolHive's vMCP uses
+// (per-session resource projection), so meta must survive it.
+func TestSessionResource_WithResult_MetaOnWire(t *testing.T) {
+	t.Parallel()
+
+	const resourceURI = "file:///session-meta-resource"
+
+	hooks := &server.Hooks{}
+	hooks.AddOnRegisterSession(func(_ context.Context, s server.ClientSession) {
+		swr, ok := s.(server.SessionWithResources)
+		require.True(t, ok, "session must implement SessionWithResources")
+		swr.SetSessionResources(map[string]server.ServerResource{
+			resourceURI: server.NewServerResourceWithResult(
+				mcp.Resource{URI: resourceURI, Name: "session-meta-resource"},
+				func(_ context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+					return &mcp.ReadResourceResult{
+						Result: mcp.Result{Meta: &mcp.Meta{
+							AdditionalFields: map[string]any{"session": "meta"},
+						}},
+						Contents: []mcp.ResourceContents{
+							mcp.TextResourceContents{URI: req.Params.URI, Text: "session body"},
+						},
+					}, nil
+				},
+			),
+		})
+	})
+
+	srv := server.NewMCPServer("session-meta-server", testClientVersion,
+		server.WithResourceCapabilities(true, true),
+		server.WithHooks(hooks),
+	)
+
+	res := readResourceOverHTTP(t, srv, resourceURI)
+	require.Len(t, res.Contents, 1)
+	require.NotNil(t, res.Meta, "per-session WithResult handler _meta must reach the wire result")
+	assert.Equal(t, "meta", res.Meta.AdditionalFields["session"])
+}

--- a/mcpcompat/server/server.go
+++ b/mcpcompat/server/server.go
@@ -72,6 +72,16 @@ type ResourceHandlerFunc func(ctx context.Context, request mcp.ReadResourceReque
 // ResourceTemplateHandlerFunc handles a templated resource read.
 type ResourceTemplateHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error)
 
+// ResourceResultHandlerFunc handles a resource read and returns the full
+// result, including the optional _meta. It is the result-returning counterpart
+// to ResourceHandlerFunc for callers that must propagate backend metadata
+// (trace ids, progress tokens, custom fields) to the client: the contents-only
+// shape (inherited from mark3labs/mcp-go, which has no result-returning
+// resource handler) has nowhere to carry _meta, so it is dropped at the go-sdk
+// boundary. Registered via AddResourceWithResult / AddResourceTemplateWithResult;
+// the returned result may be nil or carry nil Contents (a meta-only response).
+type ResourceResultHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error)
+
 // PromptHandlerFunc handles a prompt get.
 type PromptHandlerFunc func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error)
 
@@ -100,6 +110,11 @@ type ServerTool struct {
 type ServerResource struct {
 	Resource mcp.Resource
 	Handler  ResourceHandlerFunc
+
+	// resultHandler is the unwrapped result-returning handler when the
+	// resource was registered via AddResourceWithResult (Handler then carries
+	// the contents-only adapter). Nil for AddResource registrations.
+	resultHandler ResourceResultHandlerFunc
 }
 
 // ServerResourceTemplate pairs a resource template with its handler.
@@ -108,6 +123,12 @@ type ServerResource struct {
 type ServerResourceTemplate struct {
 	Template mcp.ResourceTemplate
 	Handler  ResourceTemplateHandlerFunc
+
+	// resultHandler is the unwrapped result-returning handler when the
+	// template was registered via AddResourceTemplateWithResult (Handler then
+	// carries the contents-only adapter). Nil for AddResourceTemplate
+	// registrations.
+	resultHandler ResourceResultHandlerFunc
 }
 
 // ServerPrompt pairs a prompt with its handler.
@@ -450,6 +471,65 @@ func (s *MCPServer) AddResourceTemplate(template mcp.ResourceTemplate, handler R
 	s.resourceTemplates[name] = ServerResourceTemplate{Template: template, Handler: handler}
 }
 
+// AddResourceWithResult registers a resource and a result-returning handler
+// whose _meta is forwarded onto the wire result (unlike AddResource, whose
+// contents-only handler has no meta to forward). An upsert by URI, mirroring
+// AddResource: a later registration replaces an earlier one for the same URI,
+// whichever shape either was registered with.
+func (s *MCPServer) AddResourceWithResult(resource mcp.Resource, handler ResourceResultHandlerFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resources[resource.URI] = NewServerResourceWithResult(resource, handler)
+}
+
+// AddResourceTemplateWithResult registers a resource template and a
+// result-returning handler whose _meta is forwarded onto the wire result. An
+// upsert by template name, mirroring AddResourceTemplate.
+func (s *MCPServer) AddResourceTemplateWithResult(template mcp.ResourceTemplate, handler ResourceResultHandlerFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	name := template.Name
+	s.resourceTemplates[name] = NewServerResourceTemplateWithResult(template, handler)
+}
+
+// NewServerResourceWithResult pairs a resource with a result-returning
+// handler whose _meta is served on the wire. It is the value-constructor
+// counterpart of AddResourceWithResult for registration paths that carry
+// ServerResource values (per-session SetSessionResources): the WithResult
+// registration methods only exist on MCPServer, and the unwrapped handler
+// field is unexported, so a result-returning per-session resource must be
+// built here.
+func NewServerResourceWithResult(resource mcp.Resource, handler ResourceResultHandlerFunc) ServerResource {
+	return ServerResource{Resource: resource, Handler: resultHandlerContentsAdapter(handler), resultHandler: handler}
+}
+
+// NewServerResourceTemplateWithResult is NewServerResourceWithResult for
+// resource templates (per-session SetSessionResourceTemplates).
+func NewServerResourceTemplateWithResult(
+	template mcp.ResourceTemplate, handler ResourceResultHandlerFunc,
+) ServerResourceTemplate {
+	return ServerResourceTemplate{
+		Template:      template,
+		Handler:       ResourceTemplateHandlerFunc(resultHandlerContentsAdapter(handler)),
+		resultHandler: handler,
+	}
+}
+
+// resultHandlerContentsAdapter adapts a result-returning resource handler to
+// the contents-only ResourceHandlerFunc shape: it serves Contents and drops
+// _meta. Callers that can serve _meta (wrapResourceHandler) use the unwrapped
+// resultHandler field instead; this adapter only runs on paths typed on the
+// legacy contents-only shape.
+func resultHandlerContentsAdapter(h ResourceResultHandlerFunc) ResourceHandlerFunc {
+	return func(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		res, err := h(ctx, req)
+		if err != nil || res == nil {
+			return nil, err
+		}
+		return res.Contents, nil
+	}
+}
+
 // AddPrompt registers a prompt and its handler.
 func (s *MCPServer) AddPrompt(prompt mcp.Prompt, handler PromptHandlerFunc) {
 	s.mu.Lock()
@@ -591,7 +671,7 @@ func (s *MCPServer) registerGlobalFeatures(
 		if err := jsonConvert(sr.Resource, gr); err != nil {
 			return fmt.Errorf("converting resource %q: %w", sr.Resource.URI, err)
 		}
-		srv.AddResource(gr, s.wrapResourceHandler(sr.Handler))
+		srv.AddResource(gr, s.wrapServerResource(sr))
 	}
 	for _, sp := range prompts {
 		gp := &gosdk.Prompt{}
@@ -605,7 +685,7 @@ func (s *MCPServer) registerGlobalFeatures(
 		if err := jsonConvert(srt.Template, grt); err != nil {
 			return fmt.Errorf("converting resource template %q: %w", srt.Template.Name, err)
 		}
-		h := s.wrapResourceHandler(ResourceHandlerFunc(srt.Handler))
+		h := s.wrapServerResourceTemplate(srt)
 		if err := addGlobalResourceTemplate(srv, grt, h, srt.Template.Name); err != nil {
 			return err
 		}
@@ -1022,6 +1102,20 @@ func (s *MCPServer) wrapToolHandler(h ToolHandlerFunc) gosdk.ToolHandler {
 }
 
 func (s *MCPServer) wrapResourceHandler(h ResourceHandlerFunc) gosdk.ResourceHandler {
+	return s.wrapResourceResultHandler(func(ctx context.Context, req mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		contents, err := h(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return &mcp.ReadResourceResult{Contents: contents}, nil
+	})
+}
+
+// wrapResourceResultHandler adapts a result-returning resource handler to a
+// go-sdk ResourceHandler. Unlike wrapResourceHandler it forwards the handler's
+// _meta onto the wire result; a nil result is served as an empty result (no
+// contents, no meta).
+func (s *MCPServer) wrapResourceResultHandler(h ResourceResultHandlerFunc) gosdk.ResourceHandler {
 	return func(ctx context.Context, req *gosdk.ReadResourceRequest) (res *gosdk.ReadResourceResult, err error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -1031,16 +1125,37 @@ func (s *MCPServer) wrapResourceHandler(h ResourceHandlerFunc) gosdk.ResourceHan
 		ctx = s.contextWithSession(ctx, req.Session)
 		mreq := mcp.ReadResourceRequest{}
 		mreq.Params.URI = req.Params.URI
-		contents, err := h(ctx, mreq)
+		mres, err := h(ctx, mreq)
 		if err != nil {
 			return nil, err
 		}
+		if mres == nil {
+			mres = &mcp.ReadResourceResult{}
+		}
 		out := &gosdk.ReadResourceResult{}
-		if err := jsonConvert(mcp.ReadResourceResult{Contents: contents}, out); err != nil {
+		if err := jsonConvert(mres, out); err != nil {
 			return nil, fmt.Errorf("converting resource result: %w", err)
 		}
 		return out, nil
 	}
+}
+
+// wrapServerResource picks the richest handler a ServerResource was registered
+// with: the result-returning handler (serving _meta) when present, else the
+// contents-only one.
+func (s *MCPServer) wrapServerResource(sr ServerResource) gosdk.ResourceHandler {
+	if sr.resultHandler != nil {
+		return s.wrapResourceResultHandler(sr.resultHandler)
+	}
+	return s.wrapResourceHandler(sr.Handler)
+}
+
+// wrapServerResourceTemplate is wrapServerResource for resource templates.
+func (s *MCPServer) wrapServerResourceTemplate(srt ServerResourceTemplate) gosdk.ResourceHandler {
+	if srt.resultHandler != nil {
+		return s.wrapResourceResultHandler(srt.resultHandler)
+	}
+	return s.wrapResourceHandler(ResourceHandlerFunc(srt.Handler))
 }
 
 func (s *MCPServer) wrapPromptHandler(h PromptHandlerFunc) gosdk.PromptHandler {

--- a/mcpcompat/server/session.go
+++ b/mcpcompat/server/session.go
@@ -443,7 +443,7 @@ func (s *MCPServer) syncSessionResources(srv *gosdk.Server, cs *clientSession) {
 		if err := jsonConvert(sr.Resource, gr); err != nil {
 			continue
 		}
-		srv.AddResource(gr, s.wrapResourceHandler(sr.Handler))
+		srv.AddResource(gr, s.wrapServerResource(sr))
 	}
 }
 
@@ -467,7 +467,7 @@ func (s *MCPServer) syncSessionResourceTemplates(srv *gosdk.Server, cs *clientSe
 			}
 			continue
 		}
-		if !s.addSessionResourceTemplate(srv, grt, ResourceHandlerFunc(srt.Handler)) {
+		if !s.addSessionResourceTemplate(srv, grt, srt) {
 			if s.logger != nil {
 				s.logger.Warn("skipping per-session resource template: AddResourceTemplate rejected its URI template",
 					"template", name)
@@ -482,7 +482,7 @@ func (s *MCPServer) syncSessionResourceTemplates(srv *gosdk.Server, cs *clientSe
 // the template could not be registered, so the caller skips it rather than
 // crashing the session. Mirrors addSessionTool.
 func (s *MCPServer) addSessionResourceTemplate(
-	srv *gosdk.Server, grt *gosdk.ResourceTemplate, h ResourceHandlerFunc,
+	srv *gosdk.Server, grt *gosdk.ResourceTemplate, srt ServerResourceTemplate,
 ) (ok bool) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -493,7 +493,7 @@ func (s *MCPServer) addSessionResourceTemplate(
 			ok = false
 		}
 	}()
-	srv.AddResourceTemplate(grt, s.wrapResourceHandler(h))
+	srv.AddResourceTemplate(grt, s.wrapServerResourceTemplate(srt))
 	return true
 }
 


### PR DESCRIPTION
## Summary

`mcpcompat` server resource handlers could not return `_meta`, so backend resource metadata (trace ids, progress tokens, custom fields) was dropped before the wire — even though both go-sdk and the shim's own `mcp.ReadResourceResult` support the field. The contents-only `[]ResourceContents` shape was inherited from mark3labs/mcp-go for source compatibility during the mcp-go → go-sdk migration; mcp-go has no result-returning resource handler, so this is a shim-only gap, not a compatibility constraint.

This adds a result-returning variant alongside the existing handler, additively:

- **`ResourceResultHandlerFunc`** — returns `(*mcp.ReadResourceResult, error)`
- **`AddResourceWithResult` / `AddResourceTemplateWithResult`** — global registration with meta forwarding
- **`NewServerResourceWithResult` / `NewServerResourceTemplateWithResult`** — value constructors for the per-session path (`SetSessionResources` / `SetSessionResourceTemplates`), which registers `ServerResource` values directly and can't use the `MCPServer` methods

Registered resources carry the unwrapped result handler on an unexported field; every wrap site (global registration, per-session resource/template sync) prefers it. The contents-only `Handler` field keeps its existing meaning, so existing callers compile unchanged and serve exactly as before.

Closes #194
Downstream consumer: stacklok/toolhive#6028 (vMCP `coreResourceHandler` + the stdio transport bridge).

## Test plan

- [x] New end-to-end tests in `mcpcompat/server/resource_meta_test.go`: meta on the wire for `AddResourceWithResult`, `AddResourceTemplateWithResult`, and the per-session `NewServerResourceWithResult` + `SetSessionResources` path; contents-only `AddResource` unchanged (no synthesized `_meta`)
- [x] `go test ./mcpcompat/...` green
- [x] `task lint` clean