### PR TITLE
redis: add client certificate support for mTLS

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -49,13 +49,19 @@ func NewClient(ctx context.Context, cfg *Config) (goredis.UniversalClient, error
 
 // BuildTLSConfig converts a TLSConfig into a *tls.Config suitable for
 // dialing a Redis endpoint. Returns (nil, nil) when cfg is nil, signalling
-// "no TLS". Returns an error when CACert is present but cannot be parsed.
+// "no TLS". Returns an error when the CA certificate or client certificate
+// and key cannot be parsed, or when only one of ClientCert and ClientKey is
+// set.
 //
 // The returned *tls.Config sets MinVersion to TLS 1.2 and uses the system
-// root CAs unless CACert is supplied.
+// root CAs unless CACert is supplied. When ClientCert and ClientKey are set,
+// it presents them to the server for mutual TLS.
 func BuildTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
 	if cfg == nil {
 		return nil, nil
+	}
+	if err := validateTLSConfig(cfg); err != nil {
+		return nil, fmt.Errorf("redis: invalid TLS configuration: %w", err)
 	}
 	tc := &tls.Config{
 		MinVersion:         tls.VersionTLS12,
@@ -67,6 +73,13 @@ func BuildTLSConfig(cfg *TLSConfig) (*tls.Config, error) {
 			return nil, fmt.Errorf("redis: failed to parse CA certificate PEM data")
 		}
 		tc.RootCAs = pool
+	}
+	if len(cfg.ClientCert) > 0 {
+		cert, err := tls.X509KeyPair(cfg.ClientCert, cfg.ClientKey)
+		if err != nil {
+			return nil, fmt.Errorf("redis: failed to parse client certificate and key: %w", err)
+		}
+		tc.Certificates = []tls.Certificate{cert}
 	}
 	return tc, nil
 }

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -5,7 +5,14 @@ package redis
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"testing"
 	"time"
@@ -16,9 +23,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// validPEMCert is a self-signed certificate generated solely for unit-testing
-// PEM parsing. It is never used to verify a real connection.
-const validPEMCert = `-----BEGIN CERTIFICATE-----
+const (
+	testPEMCertificate = "CERTIFICATE"
+
+	// validPEMCert is a self-signed certificate generated solely for unit-testing
+	// PEM parsing. It is never used to verify a real connection.
+	validPEMCert = `-----BEGIN CERTIFICATE-----
 MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
 DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
 EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
@@ -29,6 +39,7 @@ NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
 Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
 6MF9+Yw1Yy0t
 -----END CERTIFICATE-----`
+)
 
 func TestNewClient_Standalone(t *testing.T) {
 	t.Parallel()
@@ -46,6 +57,36 @@ func TestNewClient_Standalone(t *testing.T) {
 	got, err := client.Get(ctx, "k").Result()
 	require.NoError(t, err)
 	assert.Equal(t, "v", got)
+}
+
+func TestNewClient_StandaloneMutualTLS(t *testing.T) {
+	t.Parallel()
+
+	material := newTestTLSMaterial(t)
+	srv, err := miniredis.RunTLS(&tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{material.serverCertificate},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    material.caPool,
+	})
+	require.NoError(t, err)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(t.Context(), &Config{
+		Addr: srv.Addr(),
+		TLS: &TLSConfig{
+			CACert:     material.caPEM,
+			ClientCert: material.clientCertPEM,
+			ClientKey:  material.clientKeyPEM,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	require.NoError(t, client.Set(t.Context(), "mtls-key", "mtls-value", 0).Err())
+	value, err := client.Get(t.Context(), "mtls-key").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "mtls-value", value)
 }
 
 func TestNewClient_NilConfig(t *testing.T) {
@@ -129,11 +170,72 @@ func TestBuildTLSConfig(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse CA certificate")
 	})
+
+	t.Run("valid client certificate and key populate certificates", func(t *testing.T) {
+		t.Parallel()
+		material := newTestTLSMaterial(t)
+		got, err := BuildTLSConfig(&TLSConfig{
+			ClientCert: material.clientCertPEM,
+			ClientKey:  material.clientKeyPEM,
+		})
+		require.NoError(t, err)
+		require.Len(t, got.Certificates, 1)
+		assert.Equal(t, material.clientCertificate.Certificate[0], got.Certificates[0].Certificate[0])
+	})
+
+	t.Run("mismatched client certificate and key are rejected", func(t *testing.T) {
+		t.Parallel()
+		material := newTestTLSMaterial(t)
+		_, err := BuildTLSConfig(&TLSConfig{
+			ClientCert: material.clientCertPEM,
+			ClientKey:  material.serverKeyPEM,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "redis: failed to parse client certificate and key")
+		assert.Contains(t, err.Error(), "private key does not match public key")
+	})
+
+	for _, tt := range []struct {
+		name string
+		cfg  *TLSConfig
+	}{
+		{
+			name: "client certificate without key is rejected",
+			cfg:  &TLSConfig{ClientCert: []byte("certificate")},
+		},
+		{
+			name: "client key without certificate is rejected",
+			cfg:  &TLSConfig{ClientKey: []byte("key")},
+		},
+		{
+			name: "malformed client pair does not leak key material",
+			cfg: &TLSConfig{
+				ClientCert: []byte("certificate"),
+				ClientKey:  []byte("private-key-material"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := BuildTLSConfig(tt.cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "client certificate")
+			assert.NotContains(t, err.Error(), "private-key-material")
+		})
+	}
 }
 
-func TestBuildClient_ClusterReturnsClusterClient(t *testing.T) {
+func TestBuildClient_ClusterWithMutualTLSReturnsClusterClient(t *testing.T) {
 	t.Parallel()
-	cfg := &Config{Addr: testClusterAddr, ClusterMode: true}
+	material := newTestTLSMaterial(t)
+	cfg := &Config{
+		Addr:        testClusterAddr,
+		ClusterMode: true,
+		TLS: &TLSConfig{
+			ClientCert: material.clientCertPEM,
+			ClientKey:  material.clientKeyPEM,
+		},
+	}
 	cfg.applyDefaults()
 	c, err := buildClient(cfg)
 	require.NoError(t, err)
@@ -161,15 +263,23 @@ func TestBuildClient_SentinelReturnsFailoverClient(t *testing.T) {
 	assert.True(t, ok, "sentinel mode must return *redis.Client (failover client)")
 }
 
-func TestBuildClient_SentinelWithTLSInstallsDialer(t *testing.T) {
+func TestBuildClient_SentinelWithMutualTLSInstallsDialer(t *testing.T) {
 	t.Parallel()
+	master := newTestTLSMaterial(t)
+	sentinel := newTestTLSMaterial(t)
 	cfg := &Config{
 		SentinelConfig: &SentinelConfig{
 			MasterName:    testMasterName,
 			SentinelAddrs: []string{testSecondSentinel},
 		},
-		TLS:         &TLSConfig{InsecureSkipVerify: true},
-		SentinelTLS: &TLSConfig{InsecureSkipVerify: true},
+		TLS: &TLSConfig{
+			ClientCert: master.clientCertPEM,
+			ClientKey:  master.clientKeyPEM,
+		},
+		SentinelTLS: &TLSConfig{
+			ClientCert: sentinel.clientCertPEM,
+			ClientKey:  sentinel.clientKeyPEM,
+		},
 	}
 	cfg.applyDefaults()
 	c, err := buildClient(cfg)
@@ -223,4 +333,85 @@ func TestNewTLSDialer_SelectsConfigByAddress(t *testing.T) {
 	require.Error(t, err)
 	var netErr net.Error
 	assert.ErrorAs(t, err, &netErr)
+}
+
+type testTLSMaterial struct {
+	caPEM             []byte
+	caPool            *x509.CertPool
+	serverCertificate tls.Certificate
+	serverKeyPEM      []byte
+	clientCertificate tls.Certificate
+	clientCertPEM     []byte
+	clientKeyPEM      []byte
+}
+
+func newTestTLSMaterial(t *testing.T) testTLSMaterial {
+	t.Helper()
+
+	now := time.Now()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	ca := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test CA"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, ca, ca, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: testPEMCertificate, Bytes: caDER})
+	caPool := x509.NewCertPool()
+	require.True(t, caPool.AppendCertsFromPEM(caPEM))
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	serverDER, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}, ca, &serverKey.PublicKey, caKey)
+	require.NoError(t, err)
+	serverKeyDER, err := x509.MarshalECPrivateKey(serverKey)
+	require.NoError(t, err)
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: serverKeyDER})
+	serverCertificate, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: testPEMCertificate, Bytes: serverDER}),
+		serverKeyPEM,
+	)
+	require.NoError(t, err)
+
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	clientDER, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "test client"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}, ca, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+	clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: testPEMCertificate, Bytes: clientDER})
+	clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+	require.NoError(t, err)
+	clientKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER})
+	clientCertificate, err := tls.X509KeyPair(clientCertPEM, clientKeyPEM)
+	require.NoError(t, err)
+
+	return testTLSMaterial{
+		caPEM:             caPEM,
+		caPool:            caPool,
+		serverCertificate: serverCertificate,
+		serverKeyPEM:      serverKeyPEM,
+		clientCertificate: clientCertificate,
+		clientCertPEM:     clientCertPEM,
+		clientKeyPEM:      clientKeyPEM,
+	}
 }

--- a/redis/config.go
+++ b/redis/config.go
@@ -5,6 +5,7 @@ package redis
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -88,6 +89,11 @@ type TLSConfig struct {
 	// CACert is the PEM-encoded CA bundle used to verify the server. When
 	// nil, system root CAs are used.
 	CACert []byte
+
+	// ClientCert and ClientKey are a PEM-encoded client certificate/key pair
+	// presented to the server for mutual TLS. Both fields must be set together.
+	ClientCert []byte
+	ClientKey  []byte
 }
 
 // Validate checks Config for connection-mode topology errors and returns
@@ -116,6 +122,19 @@ func (c *Config) Validate() error {
 		if len(c.SentinelConfig.SentinelAddrs) == 0 {
 			return errors.New("at least one sentinel address is required")
 		}
+	}
+	if err := validateTLSConfig(c.TLS); err != nil {
+		return fmt.Errorf("TLS config: %w", err)
+	}
+	if err := validateTLSConfig(c.SentinelTLS); err != nil {
+		return fmt.Errorf("sentinel TLS config: %w", err)
+	}
+	return nil
+}
+
+func validateTLSConfig(cfg *TLSConfig) error {
+	if cfg != nil && (len(cfg.ClientCert) == 0) != (len(cfg.ClientKey) == 0) {
+		return errors.New("client certificate and key must be provided together")
 	}
 	return nil
 }

--- a/redis/config_test.go
+++ b/redis/config_test.go
@@ -87,6 +87,38 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: "at least one sentinel address",
 		},
 		{
+			name:    "TLS client certificate without key is rejected",
+			cfg:     &Config{Addr: testAddr, TLS: &TLSConfig{ClientCert: []byte("certificate")}},
+			wantErr: "TLS config: client certificate and key must be provided together",
+		},
+		{
+			name:    "TLS client key without certificate is rejected",
+			cfg:     &Config{Addr: testAddr, TLS: &TLSConfig{ClientKey: []byte("key")}},
+			wantErr: "TLS config: client certificate and key must be provided together",
+		},
+		{
+			name: "sentinel TLS client certificate without key is rejected",
+			cfg: &Config{
+				SentinelConfig: &SentinelConfig{
+					MasterName:    testMasterName,
+					SentinelAddrs: []string{testSentinelAddr},
+				},
+				SentinelTLS: &TLSConfig{ClientCert: []byte("certificate")},
+			},
+			wantErr: "sentinel TLS config: client certificate and key must be provided together",
+		},
+		{
+			name: "sentinel TLS client key without certificate is rejected",
+			cfg: &Config{
+				SentinelConfig: &SentinelConfig{
+					MasterName:    testMasterName,
+					SentinelAddrs: []string{testSentinelAddr},
+				},
+				SentinelTLS: &TLSConfig{ClientKey: []byte("key")},
+			},
+			wantErr: "sentinel TLS config: client certificate and key must be provided together",
+		},
+		{
 			name: "valid standalone config",
 			cfg: &Config{
 				Addr: testAddr,

--- a/redis/doc.go
+++ b/redis/doc.go
@@ -50,7 +50,9 @@ TLS is opt-in per connection target. When TLS is set, master/cluster
 connections use it. SentinelTLS, when set, applies to sentinel daemon
 connections independently — useful when the master and sentinels present
 different certificate chains. Both fields accept either system CAs (CACert
-nil) or a custom CA bundle.
+nil) or a custom CA bundle. To use mTLS, set ClientCert and ClientKey to a
+PEM-encoded client certificate/key pair; the master and sentinel connections
+can use different pairs.
 
 # Defaults and Validation
 


### PR DESCRIPTION
## Summary

- add PEM-backed client certificate and key fields for Redis/Valkey mTLS
- validate incomplete or malformed client credential pairs without exposing credential data in errors
- cover standalone mTLS, cluster and Sentinel construction, and invalid/mismatched credential cases

## Verification

- `go test -race ./redis`
- `task`
- `task license-check`

Fixes #240